### PR TITLE
Add product vision and phased roadmap: the brainstorm is the product

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,52 @@
+# Roadmap — Beyond Syllabus
+
+*Phased against [VISION.md](./VISION.md). Community issues [#10–#19](https://github.com/The-Purple-Movement/Beyond-Syllabus/issues) are mapped into phases below — the community already told us what to build; this file puts it in order.*
+
+**Current state (July 2026):** Next.js 16 + React 19 + Bun monorepo with a Groq-powered chat, AI module summaries, mind-maps, and share links, fed by a build-time snapshot of WikiSyllabus (12 universities). Solid skeleton, real gaps: no brainstorm/Socratic mode, no persistence or progress, a 12 MB all-universities JSON payload, manual syllabus sync, no tests or CI.
+
+## Phase 0 — Hygiene & trust (weeks, not months)
+
+The unglamorous work that makes contributors take the repo seriously:
+
+- [ ] **CI**: lint + typecheck + build on every PR (`oxlint` exists; wire it to GitHub Actions)
+- [ ] **Move all LLM calls server-side** — today Groq calls run in web server actions with the key in web env (and a `'api key'` string fallback in `ai.ts`). Single AI route on the server app, key lives only there, rate-limited
+- [ ] **Split the 12 MB syllabus.json** — serve per-university/per-course slices from the oRPC API; mobile-data users are the design target (vision principle 3)
+- [ ] **Automated WikiSyllabus sync** — nightly GitHub Action replaces the manual `bun sync`; new syllabus merged upstream appears here within 24h, no human in the loop
+- [ ] **Replace the keyword-blocklist topic filter** with prompt-level scoping (today "bollywood" is hard-blocked — a film-studies student literally can't ask about their own syllabus)
+- [ ] Label 10+ `good first issue`s from this list; add PR preview deploys
+
+## Phase 1 — The brainstorm becomes the product (months 1–3)
+
+The flipped-classroom core (vision moment #1):
+
+- [ ] **Guided Brainstorm mode**: module-scoped session — activate prior knowledge → why/where context → surface confusions. Distinct UI from chat; this is the flagship flow, not a prompt preset
+- [ ] **The Question Sheet**: every brainstorm produces a takeaway list of the student's open questions — exportable, shareable (permanent links, not 7-day Redis TTL), and designed to be *brought to class* (issue #17's notes problem, solved at the artifact level)
+- [ ] **Socratic mode in chat**: answer, then turn it back — a mentor persona that ends responses with a forward question (the persona/prompt-builder system already supports this cleanly)
+- [ ] **Prerequisite awareness v1** (issue #15): module-to-module "builds on" links generated from syllabus structure, shown before each brainstorm — "this stands on Module 2; shaky there? start there"
+- [ ] **Relatable-examples pass** (issue #12): region- and industry-anchored examples in module context, with a community contribution path for better ones
+
+## Phase 2 — Continuity & motivation (months 4–6)
+
+- [ ] **Lightweight accounts** (optional, never required to learn): saved brainstorms, question sheets, per-module progress
+- [ ] **Progress & streaks** (issue #18): module completion, brainstorm streaks — designed for eventual **μLearn Karma interop**, not a parallel points economy
+- [ ] **Exam runway** (issue #14): enter exam dates → module-by-module revision plan built from your progress and prerequisite graph
+- [ ] **Foundation check** (vision moment #3): per-module self-assessment; **PYQ integration** (issue #16) where the community contributes previous-year questions via WikiSyllabus-style open files
+- [ ] **Personalized delivery modes** (issue #11): explain-like-a-peer / formal / example-first as a user setting (persona system already models this)
+
+## Phase 3 — The classroom loop & the network (months 7–12)
+
+- [ ] **Teacher view**: anonymized, aggregated Question Sheets per class/module — the flipped classroom's teacher half. Ship to 2–3 pilot classrooms via the μLearn campus network before generalizing
+- [ ] **Offline-tolerant PWA** (issue #19): cached syllabus + brainstorm artifacts survive patchy data; AI degrades gracefully to structured prompts
+- [ ] **Ecosystem hand-offs**: module → related Beyond-Borders problem statements ("what could you build with this?"); course → upcoming Evolve sessions in that domain
+- [ ] **Coverage push with WikiSyllabus** (issue #10): coordinated campaign for niche departments and more universities — every new syllabus file lights up a course here automatically (Phase 0 sync makes this real)
+
+## Metrics that match the mission
+
+- Questions brought to class (sheets created/exported) — the north star
+- Brainstorm sessions per active student per week; % of universities in WikiSyllabus live here within 24h of merge
+- Contributor count and time-to-first-merged-PR
+- **Not** metrics: total chat messages, session length. An answer machine maximizes those; a question machine doesn't.
+
+## How to pick something up
+
+Comment on the mapped issue, or open one referencing the roadmap line. Architecture questions → open a discussion. New contributors: start at `good first issue` — Phase 0 items are deliberately scoped to be first PRs.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,50 @@
+# Vision — Beyond Syllabus
+
+> **The classroom should be where you ask your best questions — not where you hear the material for the first time.**
+
+## The one-line product
+
+Beyond Syllabus is the tool a student opens **before** class: they brainstorm with their syllabus, build the foundations on their own terms, and walk into the classroom carrying questions — flipping the classroom from a place of passive coverage into a place of active inquiry.
+
+## Why "chat with your syllabus" is not the product
+
+A syllabus chatbot answers questions. That's table stakes — every general AI assistant can do it, and ChatGPT will always have more compute than us. What no general assistant has is:
+
+1. **The exact curriculum context** — module by module, university by university, revision by revision, via [WikiSyllabus](https://github.com/The-Purple-Movement/WikiSyllabus)
+2. **A pedagogy** — we are not trying to answer the student's questions as fast as possible; we are trying to make the student's *questions better*
+3. **A community** — [μLearn](https://mulearn.org/)'s 48,000+ peer learners, and the [Evolve](https://github.com/deepusnath/Beyond-Gatekeepers) practitioner network, on the same mission
+
+The product is the **brainstorm, not the answer**. Success for a session is not "the AI explained it well." Success is: *the student left with three questions they're excited to ask in class tomorrow.*
+
+## The three student moments we serve
+
+### 1. Before class — "Prime me" (the flipped-classroom core)
+The student picks tomorrow's module. Beyond Syllabus runs a **guided brainstorm**: what do you already know that this builds on? Here's the why behind this topic, here's where it's used in the real world — now, what doesn't make sense yet? Output: a **Question Sheet** — their personal list of questions to bring to class. That artifact is the flipped classroom, made concrete.
+
+### 2. While studying — "Go deeper" (the Socratic companion)
+Chat that deliberately behaves like a mentor, not an answer machine: it answers with context, then turns the question back — *"you now know X; what would happen if Y?"* Prerequisite-aware (knows what earlier modules the current one stands on), example-rich (relatable, local, industry-anchored), and honest about the syllabus's edges — pointing beyond it, by design.
+
+### 3. Before exams — "Ground me" (the foundation check)
+Module-by-module self-assessment against the actual syllabus: what's solid, what's shaky, what to revisit — connected to previous-year questions where the community has contributed them.
+
+## Who else it serves
+
+- **Teachers**: a class-level view of the Question Sheets students bring (anonymized, aggregated) is the most honest signal a teacher can get about where the class actually is. Teachers are the other half of the flipped classroom; we build *for* them, never around them.
+- **Contributors**: every syllabus in WikiSyllabus lights up a course here. Every example, use-case, or PYQ contributed makes the brainstorm richer for the next student. Contribution is the currency, μLearn-style.
+
+## Product principles
+
+1. **Questions over answers.** Every feature is measured by whether it improves the questions students ask.
+2. **The syllabus is the map, not the territory.** We always show where the syllabus ends and the frontier begins — and hand off to [Beyond Borders](https://github.com/The-Purple-Movement/Beyond-Borders) for what to build.
+3. **Free forever, light by default.** Students on entry-level phones with patchy data are the design target, not an afterthought (offline-tolerant, small payloads — see roadmap).
+4. **Open pipeline.** WikiSyllabus → Beyond Syllabus stays a fully open, inspectable data path. New syllabus in Git = new course live, no gatekeeping.
+5. **Movement-native.** Progress mechanics align with μLearn Karma; community links point at Evolve chapters; industry context flows from Beyond Borders.
+
+## What we are not
+
+- Not a notes app, not an LMS, not a proctoring tool — and never an exam-cram shortcut machine. If a feature optimizes rote memorisation, it's off-mission.
+- Not a walled garden. No feature may require an account to *learn*; accounts only ever add continuity (progress, saved brainstorms).
+
+---
+
+*This vision implements the Beyond Syllabus pillar of [The Purple Movement](https://purple-movement.com/): the syllabus is a starting point, not a cage. See [ROADMAP.md](./ROADMAP.md) for the build order.*


### PR DESCRIPTION
docs/VISION.md defines Beyond Syllabus around the flipped classroom: three student moments (prime me before class, go deeper while studying, ground me before exams), the Question Sheet as the core artifact, a teacher-side loop, and the north-star metric: questions brought to class, not chat volume.

docs/ROADMAP.md sequences it in four phases, starting with hygiene (CI, server-side LLM calls, splitting the 12MB payload, automated WikiSyllabus sync) and mapping community issues #10-#19 into the phases.

Prepared with Deepu S. Nath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)