### PR TITLE
Phase 1: Guided Brainstorm mode and the Question Sheet

### DIFF
--- a/apps/web/src/ai/flows/chat-with-syllabus.ts
+++ b/apps/web/src/ai/flows/chat-with-syllabus.ts
@@ -160,6 +160,7 @@ const chatWithSyllabusFlow = async (
           ? ["Multiple concrete examples"]
           : ["Relevant examples"]),
         "Natural, engaging communication style",
+        "End with one short Socratic follow-up question that invites the student to reason one step further on this topic",
       ],
     },
     format: {

--- a/apps/web/src/ai/flows/guided-brainstorm.ts
+++ b/apps/web/src/ai/flows/guided-brainstorm.ts
@@ -1,0 +1,123 @@
+"use server";
+
+import { ai } from "@/ai/ai";
+import { Message } from "@/lib/types";
+
+export type BrainstormStage = "prime" | "explore" | "question";
+
+export interface GuidedBrainstormInput {
+  stage: BrainstormStage;
+  moduleTitle: string;
+  moduleContent: string;
+  history: Message[];
+  /** Empty string on stage entry: the flow produces the stage's opening move */
+  message: string;
+  model?: string;
+}
+
+export interface GuidedBrainstormOutput {
+  response: string;
+  /** Classroom-ready candidate questions distilled from this exchange */
+  suggestedQuestions: string[];
+}
+
+const STAGE_GOALS: Record<BrainstormStage, string> = {
+  prime: `STAGE: PRIME (activate prior knowledge).
+Your job is to find out what the student already knows and hook this module onto it.
+- Open by asking what they already know, have heard about, or have used related to this module. Everyday experience counts.
+- Affirm partial knowledge; never quiz-shame. Wrong guesses are raw material, treat them warmly and note what the guess got right.
+- Connect what they say to the module's foundations in one or two sentences at a time.
+- Keep every turn under 120 words. One question per turn, never more.`,
+  explore: `STAGE: EXPLORE (why this matters, where it lives in the real world).
+Your job is to make the module feel worth learning before class covers it.
+- Give the why behind topics: what problem did this solve, who uses it today, one concrete and locally relatable example.
+- Prefer vivid, specific examples over coverage. One idea per turn.
+- Keep every turn under 150 words, and end each turn with one forward question that invites the student to predict, guess, or connect.`,
+  question: `STAGE: QUESTION (turn confusion into classroom-ready questions).
+Your job is to help the student leave with sharp questions to ask in class, NOT to answer everything yourself.
+- When the student voices a confusion or half-formed thought, reflect it back as one or two well-formed, specific questions they could ask their teacher.
+- A good question names the concept, states what is understood, and pinpoints where understanding breaks.
+- Resist answering deep questions fully: sharpen them instead, and say why it is a good question to bring to class.
+- Keep every turn under 120 words.`,
+};
+
+function buildSystemPrompt(input: GuidedBrainstormInput): string {
+  return `You are the Guided Brainstorm companion in Beyond Syllabus, an open-source tool of The Purple Movement. The student is preparing BEFORE class (flipped classroom). Success is NOT that you explained well; success is that the student leaves with better questions than they came with.
+
+MODULE: ${input.moduleTitle}
+MODULE CONTENT (your only syllabus scope):
+${input.moduleContent}
+
+${STAGE_GOALS[input.stage]}
+
+RULES FOR EVERY TURN:
+- Warm, direct, peer-mentor voice. No lecturing, no walls of text.
+- Stay anchored to this module; if the student drifts far off, steer back kindly using the module content.
+- After your reply, on new lines, output exactly:
+QUESTIONS:
+- <up to 3 short, classroom-ready questions that capture the student's current live confusions or curiosities, written in the student's voice>
+If nothing new emerged this turn, repeat the single best open question so far. Never omit the QUESTIONS block.`;
+}
+
+function parseOutput(raw: string): GuidedBrainstormOutput {
+  const marker = /\nQUESTIONS:\s*\n/i;
+  const match = raw.split(marker);
+  if (match.length >= 2) {
+    const response = match[0].trim();
+    const questions = match[match.length - 1]
+      .split("\n")
+      .map((l) => l.replace(/^[-*]\s*/, "").trim())
+      .filter((l) => l.length > 5 && l.length < 240)
+      .slice(0, 3);
+    if (response) return { response, suggestedQuestions: questions };
+  }
+  return { response: raw.trim(), suggestedQuestions: [] };
+}
+
+const STAGE_OPENERS: Record<BrainstormStage, string> = {
+  prime:
+    "Begin the PRIME stage now: greet the student in one short line and ask your opening prior-knowledge question about this module.",
+  explore:
+    "Begin the EXPLORE stage now: in one short move, give the most compelling real-world reason this module exists, then ask your forward question.",
+  question:
+    "Begin the QUESTION stage now: briefly recap (one line) the most interesting thread so far if any, then invite the student to voice what still feels foggy so you can shape it into questions for class.",
+};
+
+export async function guidedBrainstorm(
+  input: GuidedBrainstormInput
+): Promise<GuidedBrainstormOutput> {
+  try {
+    const history = input.history
+      .filter((m) => m.role !== "system")
+      .slice(-12)
+      .map((m) => ({ role: m.role, content: m.content }));
+
+    const userContent =
+      input.message.trim() || STAGE_OPENERS[input.stage];
+
+    const completion = await ai.chat.completions.create({
+      messages: [
+        { role: "system", content: buildSystemPrompt(input) },
+        ...history,
+        { role: "user", content: userContent },
+      ],
+      model: input.model || "llama-3.1-8b-instant",
+      temperature: 0.6,
+      max_completion_tokens: 700,
+      top_p: 0.9,
+    });
+
+    const raw = completion.choices?.[0]?.message?.content || "";
+    if (!raw) {
+      throw new Error("Empty model response");
+    }
+    return parseOutput(raw);
+  } catch (e) {
+    console.error("Error in guided brainstorm flow:", e);
+    return {
+      response:
+        "Something went wrong on my side. Give it another try, or rephrase your last thought.",
+      suggestedQuestions: [],
+    };
+  }
+}

--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/CourseModules.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/CourseModules.tsx
@@ -107,6 +107,20 @@ export function CourseModules({ modules }: CourseModulesProps) {
                     )}
                     Chat with AI about this Module
                   </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      router.push(
+                        `/brainstorm?title=${encodeURIComponent(
+                          module.title || "Selected Module"
+                        )}&content=${encodeURIComponent(module.content)}`
+                      )
+                    }
+                    className="flex items-center gap-2 mt-2 border-primary/40 text-primary hover:bg-primary/10"
+                  >
+                    <BrainCircuit className="h-4 w-4" />
+                    Brainstorm before class
+                  </Button>
                 </AccordionContent>
               </AccordionItem>
             </motion.div>

--- a/apps/web/src/app/brainstorm/page.tsx
+++ b/apps/web/src/app/brainstorm/page.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import ChatMessage from "@/app/chat/_components/ChatMessage";
+import { ChatInput } from "@/app/chat/_components/ChatInput";
+import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import {
+  guidedBrainstorm,
+  BrainstormStage,
+} from "@/ai/flows/guided-brainstorm";
+import { Message } from "@/lib/types";
+import {
+  ArrowRight,
+  Download,
+  Lightbulb,
+  ListChecks,
+  Plus,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
+import { toast } from "react-hot-toast";
+
+type SheetQuestion = {
+  id: string;
+  text: string;
+  source: "ai" | "mine";
+};
+
+const STAGES: { id: BrainstormStage; label: string; hint: string }[] = [
+  { id: "prime", label: "1 · Prime", hint: "What do you already know?" },
+  { id: "explore", label: "2 · Explore", hint: "Why does this matter?" },
+  { id: "question", label: "3 · Questions", hint: "What will you ask in class?" },
+];
+
+export default function BrainstormPage() {
+  const [moduleTitle, setModuleTitle] = useState("");
+  const [moduleContent, setModuleContent] = useState("");
+  const [stage, setStage] = useState<BrainstormStage>("prime");
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [candidates, setCandidates] = useState<string[]>([]);
+  const [sheet, setSheet] = useState<SheetQuestion[]>([]);
+  const [ownQuestion, setOwnQuestion] = useState("");
+  const [model, setModel] = useState("openai/gpt-oss-120b");
+  const startedStages = useRef<Set<string>>(new Set());
+  const endRef = useRef<HTMLDivElement>(null);
+
+  const storageKey = moduleTitle ? `question-sheet:${moduleTitle}` : null;
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setModuleTitle(params.get("title") || "");
+    setModuleContent(params.get("content") || "");
+  }, []);
+
+  // Restore a previously built sheet for this module
+  useEffect(() => {
+    if (!storageKey) return;
+    try {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) setSheet(JSON.parse(saved));
+    } catch {
+      /* corrupted sheet: start fresh */
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (storageKey) localStorage.setItem(storageKey, JSON.stringify(sheet));
+  }, [sheet, storageKey]);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, loading]);
+
+  const runTurn = useCallback(
+    async (message: string, forStage: BrainstormStage, history: Message[]) => {
+      setLoading(true);
+      try {
+        const result = await guidedBrainstorm({
+          stage: forStage,
+          moduleTitle,
+          moduleContent,
+          history,
+          message,
+          model,
+        });
+        setMessages((prev) => [
+          ...prev,
+          { role: "assistant", content: result.response },
+        ]);
+        if (result.suggestedQuestions.length) {
+          setCandidates(result.suggestedQuestions);
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [moduleTitle, moduleContent, model]
+  );
+
+  // Stage opener: fires once per stage, once module context exists
+  useEffect(() => {
+    if (!moduleContent || !moduleTitle) return;
+    if (startedStages.current.has(stage)) return;
+    startedStages.current.add(stage);
+    runTurn("", stage, messages);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [moduleContent, moduleTitle, stage]);
+
+  const handleSend = async (message: string) => {
+    if (!message.trim() || loading) return;
+    const next: Message[] = [...messages, { role: "user", content: message }];
+    setMessages(next);
+    await runTurn(message, stage, next);
+  };
+
+  const addToSheet = (text: string, source: "ai" | "mine") => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    if (sheet.some((q) => q.text === trimmed)) {
+      toast("Already on your sheet");
+      return;
+    }
+    setSheet((prev) => [
+      ...prev,
+      { id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`, text: trimmed, source },
+    ]);
+  };
+
+  const exportSheet = () => {
+    const lines = [
+      `# Question Sheet — ${moduleTitle}`,
+      "",
+      `*Built with Beyond Syllabus Guided Brainstorm. Bring these to class.*`,
+      "",
+      ...sheet.map((q, i) => `${i + 1}. ${q.text}`),
+      "",
+      `— ${new Date().toLocaleDateString()}`,
+    ];
+    const blob = new Blob([lines.join("\n")], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `question-sheet-${moduleTitle.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast.success("Question Sheet downloaded");
+  };
+
+  const stageIndex = STAGES.findIndex((s) => s.id === stage);
+  const nextStage = STAGES[stageIndex + 1];
+
+  if (!moduleTitle || !moduleContent) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 via-white to-mint-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-800 p-6">
+        <div className="text-center max-w-md space-y-4">
+          <Sparkles className="h-10 w-10 mx-auto text-primary" />
+          <h1 className="text-2xl font-bold">Guided Brainstorm</h1>
+          <p className="text-muted-foreground">
+            Open a module from your syllabus and choose Brainstorm to start a
+            session. You will leave with a Question Sheet to bring to class.
+          </p>
+          <Button asChild>
+            <Link href="/select">Find your syllabus</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gradient-to-br from-purple-50 via-white to-mint-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-800">
+      {/* Header */}
+      <header className="flex items-center justify-between px-4 py-3 border-b border-border/50 backdrop-blur-sm sticky top-0 z-20 bg-background/70">
+        <div className="min-w-0">
+          <p className="text-xs text-muted-foreground uppercase tracking-wide">
+            Guided Brainstorm
+          </p>
+          <h1 className="font-semibold truncate max-w-[60vw]">{moduleTitle}</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+        </div>
+      </header>
+
+      {/* Stage rail */}
+      <div className="flex items-center justify-center gap-2 px-4 py-3 flex-wrap">
+        {STAGES.map((s, i) => (
+          <button
+            key={s.id}
+            type="button"
+            onClick={() => i <= stageIndex && setStage(s.id)}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all border ${
+              s.id === stage
+                ? "bg-primary text-white border-primary"
+                : i < stageIndex
+                  ? "bg-primary/10 text-primary border-primary/30"
+                  : "bg-muted text-muted-foreground border-transparent cursor-default"
+            }`}
+            title={s.hint}
+          >
+            {s.label}
+          </button>
+        ))}
+        {nextStage && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="rounded-full text-xs h-7"
+            disabled={loading}
+            onClick={() => setStage(nextStage.id)}
+          >
+            Next: {nextStage.label.split("· ")[1]}
+            <ArrowRight className="h-3 w-3 ml-1" />
+          </Button>
+        )}
+      </div>
+
+      <div className="flex flex-1 gap-4 px-4 pb-4 max-w-6xl w-full mx-auto min-h-0 flex-col lg:flex-row">
+        {/* Conversation */}
+        <div className="flex-1 flex flex-col min-w-0">
+          <div className="flex-1 overflow-y-auto space-y-4 pr-1 pb-4">
+            {messages
+              .filter((m) => m.role !== "system")
+              .map((m, i) => (
+                <ChatMessage
+                  key={i}
+                  role={m.role as "user" | "assistant"}
+                  content={m.content}
+                />
+              ))}
+            {loading && (
+              <p className="text-sm text-muted-foreground animate-pulse px-2">
+                Thinking with you…
+              </p>
+            )}
+            <div ref={endRef} />
+          </div>
+
+          {/* AI-suggested questions for the sheet */}
+          {candidates.length > 0 && (
+            <div className="mb-3 space-y-1.5">
+              <p className="text-xs font-medium text-muted-foreground flex items-center gap-1">
+                <Lightbulb className="h-3.5 w-3.5" /> Worth asking in class? Tap
+                to add to your sheet:
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {candidates.map((q) => (
+                  <button
+                    key={q}
+                    type="button"
+                    onClick={() => addToSheet(q, "ai")}
+                    className="text-left text-xs px-3 py-1.5 rounded-xl border border-primary/30 bg-primary/5 hover:bg-primary/15 transition-colors"
+                  >
+                    <Plus className="h-3 w-3 inline mr-1" />
+                    {q}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <ChatInput
+            placeholder={STAGES[stageIndex].hint}
+            onSend={handleSend}
+            disabled={loading}
+            onModelChange={setModel}
+          />
+        </div>
+
+        {/* Question Sheet */}
+        <aside className="lg:w-80 w-full shrink-0">
+          <div className="rounded-2xl border border-border/60 bg-background/70 backdrop-blur-sm p-4 lg:sticky lg:top-20 space-y-3">
+            <div className="flex items-center justify-between">
+              <h2 className="font-semibold flex items-center gap-2 text-sm">
+                <ListChecks className="h-4 w-4 text-primary" /> Question Sheet
+                <span className="text-xs text-muted-foreground">
+                  ({sheet.length})
+                </span>
+              </h2>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 px-2"
+                disabled={!sheet.length}
+                onClick={exportSheet}
+                title="Download as markdown"
+              >
+                <Download className="h-4 w-4" />
+              </Button>
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+              The point of this session: walk into class with questions worth
+              asking.
+            </p>
+
+            <ul className="space-y-2 max-h-[40vh] overflow-y-auto">
+              {sheet.map((q, i) => (
+                <li
+                  key={q.id}
+                  className="group flex items-start gap-2 text-sm rounded-lg border border-border/50 px-2.5 py-2"
+                >
+                  <span className="text-xs text-muted-foreground mt-0.5">
+                    {i + 1}.
+                  </span>
+                  <span className="flex-1">{q.text}</span>
+                  <button
+                    type="button"
+                    className="opacity-0 group-hover:opacity-100 transition-opacity"
+                    onClick={() =>
+                      setSheet((prev) => prev.filter((x) => x.id !== q.id))
+                    }
+                    aria-label="Remove question"
+                  >
+                    <Trash2 className="h-3.5 w-3.5 text-muted-foreground hover:text-destructive" />
+                  </button>
+                </li>
+              ))}
+              {!sheet.length && (
+                <li className="text-xs text-muted-foreground italic px-1">
+                  Empty so far. Add the AI's suggestions below the chat, or
+                  write your own here.
+                </li>
+              )}
+            </ul>
+
+            <form
+              className="flex gap-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                addToSheet(ownQuestion, "mine");
+                setOwnQuestion("");
+              }}
+            >
+              <input
+                value={ownQuestion}
+                onChange={(e) => setOwnQuestion(e.target.value)}
+                placeholder="Write your own question…"
+                className="flex-1 text-sm rounded-lg border border-border/60 bg-background px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/40"
+              />
+              <Button type="submit" size="sm" variant="outline" className="h-8">
+                <Plus className="h-4 w-4" />
+              </Button>
+            </form>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
The flipped-classroom core from [docs/VISION.md](https://github.com/The-Purple-Movement/Beyond-Syllabus/blob/main/docs/VISION.md), implemented (roadmap Phase 1):

## What's new

- **`/brainstorm`**: a three-stage guided session per module: **Prime** (what do you already know?) → **Explore** (why does this matter in the real world?) → **Questions** (turn confusion into classroom-ready questions). Distinct UI from chat, per the vision: this is the flagship flow, not a prompt preset.
- **The Question Sheet**: the session's takeaway artifact. Every AI turn proposes up to three classroom-ready candidate questions (tap to add); students also write their own. The sheet persists per module (localStorage) and **exports as markdown to bring to class**. This artifact is the product's north-star metric made tangible: questions brought to class, not chat volume.
- **Stage-aware AI flow** (`guided-brainstorm.ts`): prompts whose stated success is better student questions, not faster answers. In the Questions stage the model deliberately sharpens rather than answers. Robust QUESTIONS-block parsing with graceful degradation.
- **Entry point**: a 'Brainstorm before class' button on every module accordion.
- **Socratic close in regular chat**: responses now end with one short forward question.

## Verification

Build, lint, typecheck green. Browser-tested end to end: stage rail progression, question add/remove, per-module persistence across reload, markdown export, module-page navigation with content passthrough, and the graceful fallback when no GROQ key is configured. Live AI conversation quality needs a keyed environment: reviewers, that's the one thing to taste-test before merge.

Prepared with Deepu S. Nath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)