### PR TITLE
Phase 2 slice: the Journey layer (local-first progress, streaks, delivery modes)

### DIFF
--- a/apps/web/src/ai/flows/guided-brainstorm.ts
+++ b/apps/web/src/ai/flows/guided-brainstorm.ts
@@ -13,6 +13,8 @@ export interface GuidedBrainstormInput {
   /** Empty string on stage entry: the flow produces the stage's opening move */
   message: string;
   model?: string;
+  /** Student's preferred voice, from their Journey settings */
+  deliveryMode?: "peer" | "mentor" | "example-first";
 }
 
 export interface GuidedBrainstormOutput {
@@ -41,8 +43,21 @@ Your job is to help the student leave with sharp questions to ask in class, NOT 
 - Keep every turn under 120 words.`,
 };
 
+const DELIVERY_VOICES: Record<
+  NonNullable<GuidedBrainstormInput["deliveryMode"]>,
+  string
+> = {
+  peer: "VOICE: talk like a sharp classmate. Casual, direct, zero jargon, humor welcome.",
+  mentor:
+    "VOICE: talk like a warm mentor. Encouraging, clear, guiding without lecturing.",
+  "example-first":
+    "VOICE: open every idea with a concrete, relatable example before naming the concept.",
+};
+
 function buildSystemPrompt(input: GuidedBrainstormInput): string {
   return `You are the Guided Brainstorm companion in Beyond Syllabus, an open-source tool of The Purple Movement. The student is preparing BEFORE class (flipped classroom). Success is NOT that you explained well; success is that the student leaves with better questions than they came with.
+
+${DELIVERY_VOICES[input.deliveryMode || "mentor"]}
 
 MODULE: ${input.moduleTitle}
 MODULE CONTENT (your only syllabus scope):

--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/CourseModules.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/CourseModules.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Accordion,
   AccordionContent,
@@ -13,12 +13,53 @@ import { Sparkles, BrainCircuit } from "lucide-react";
 import { motion } from "framer-motion";
 import { Spinner } from "@/components/ui/spinner";
 import { Module, CourseModulesProps } from "@/lib/types";
+import {
+  getModuleStatus,
+  setModuleStatus,
+  ModuleStatus,
+} from "@/lib/journey";
+
+const STATUS_OPTIONS: { id: ModuleStatus; label: string; active: string }[] = [
+  {
+    id: "shaky",
+    label: "Shaky",
+    active:
+      "bg-amber-500/15 text-amber-600 dark:text-amber-400 border-amber-500/40",
+  },
+  {
+    id: "explored",
+    label: "Getting there",
+    active: "bg-blue-500/15 text-blue-600 dark:text-blue-400 border-blue-500/40",
+  },
+  {
+    id: "solid",
+    label: "Solid",
+    active:
+      "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 border-emerald-500/40",
+  },
+];
 
 export function CourseModules({ modules }: CourseModulesProps) {
   const router = useRouter();
   const [loadingModuleIndex, setLoadingModuleIndex] = useState<number | null>(
     null
   );
+  const [statuses, setStatuses] = useState<Record<string, ModuleStatus | null>>(
+    {}
+  );
+
+  useEffect(() => {
+    const initial: Record<string, ModuleStatus | null> = {};
+    for (const m of modules) {
+      if (m.title) initial[m.title] = getModuleStatus(m.title);
+    }
+    setStatuses(initial);
+  }, [modules]);
+
+  const updateStatus = (title: string, status: ModuleStatus) => {
+    setModuleStatus(title, status);
+    setStatuses((prev) => ({ ...prev, [title]: status }));
+  };
 
   const handleChatRedirect = async (module: Module, index: number) => {
     if (!module.content.trim()) {
@@ -121,6 +162,27 @@ export function CourseModules({ modules }: CourseModulesProps) {
                     <BrainCircuit className="h-4 w-4" />
                     Brainstorm before class
                   </Button>
+                  {module.title && (
+                    <div className="mt-4 flex flex-wrap items-center gap-2">
+                      <span className="text-xs text-muted-foreground">
+                        Where do you stand on this module?
+                      </span>
+                      {STATUS_OPTIONS.map((opt) => (
+                        <button
+                          key={opt.id}
+                          type="button"
+                          onClick={() => updateStatus(module.title!, opt.id)}
+                          className={`text-[11px] px-2.5 py-1 rounded-full border transition-colors ${
+                            statuses[module.title!] === opt.id
+                              ? opt.active
+                              : "border-border/60 text-muted-foreground hover:bg-muted"
+                          }`}
+                        >
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 </AccordionContent>
               </AccordionItem>
             </motion.div>

--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/page.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/page.tsx
@@ -8,7 +8,8 @@ import { CourseModules } from "./_components/CourseModules";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import { AnimatedDiv } from "@/components/AnimatedDiv";
 
-import { useData } from "@/contexts";
+import { useUniversityData } from "@/contexts";
+import { Spinner } from "@/components/ui/spinner";
 import { use } from "react";
 import { SubjectPageProps, DirectoryStructure } from "@/lib/types";
 import { Header } from "@/components/Header";
@@ -81,7 +82,23 @@ function capitalizeWords(str: string | undefined): string {
 
 export default function SubjectPage({ params }: SubjectPageProps) {
   const resolvedParams = use(params);
-  const { error, isError, data: directoryStructure } = useData();
+  const {
+    error,
+    isError,
+    isFetching,
+    data: directoryStructure,
+  } = useUniversityData(resolvedParams.university);
+
+  if (isFetching) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="text-center">
+          <Spinner className="h-8 w-8 mx-auto mb-4" />
+          <p className="text-muted-foreground">Loading syllabus data...</p>
+        </div>
+      </div>
+    );
+  }
 
   if (isError || !directoryStructure) {
     return (

--- a/apps/web/src/app/brainstorm/page.tsx
+++ b/apps/web/src/app/brainstorm/page.tsx
@@ -12,6 +12,12 @@ import {
 } from "@/ai/flows/guided-brainstorm";
 import { Message } from "@/lib/types";
 import {
+  getDeliveryMode,
+  recordBrainstormSession,
+  recordQuestionCollected,
+} from "@/lib/journey";
+import { Map } from "lucide-react";
+import {
   ArrowRight,
   Download,
   Lightbulb,
@@ -85,6 +91,7 @@ export default function BrainstormPage() {
           history,
           message,
           model,
+          deliveryMode: getDeliveryMode(),
         });
         setMessages((prev) => [
           ...prev,
@@ -105,6 +112,7 @@ export default function BrainstormPage() {
     if (!moduleContent || !moduleTitle) return;
     if (startedStages.current.has(stage)) return;
     startedStages.current.add(stage);
+    if (stage === "prime") recordBrainstormSession(moduleTitle);
     runTurn("", stage, messages);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [moduleContent, moduleTitle, stage]);
@@ -127,6 +135,7 @@ export default function BrainstormPage() {
       ...prev,
       { id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`, text: trimmed, source },
     ]);
+    recordQuestionCollected(moduleTitle);
   };
 
   const exportSheet = () => {
@@ -181,6 +190,11 @@ export default function BrainstormPage() {
           <h1 className="font-semibold truncate max-w-[60vw]">{moduleTitle}</h1>
         </div>
         <div className="flex items-center gap-2">
+          <Button asChild variant="ghost" size="sm" title="My Journey">
+            <Link href="/journey">
+              <Map className="h-4 w-4" />
+            </Link>
+          </Button>
           <ThemeToggle />
         </div>
       </header>

--- a/apps/web/src/app/journey/page.tsx
+++ b/apps/web/src/app/journey/page.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import {
+  DeliveryMode,
+  Journey,
+  loadJourney,
+  setDeliveryMode,
+  getStreak,
+  exportAllData,
+  importAllData,
+  setModuleStatus,
+  ModuleStatus,
+} from "@/lib/journey";
+import {
+  Download,
+  Flame,
+  ListChecks,
+  Map,
+  Sparkles,
+  Upload,
+} from "lucide-react";
+import { toast } from "react-hot-toast";
+
+const MODES: { id: DeliveryMode; label: string; blurb: string }[] = [
+  { id: "peer", label: "Like a peer", blurb: "Casual, relatable, zero jargon" },
+  { id: "mentor", label: "Like a mentor", blurb: "Warm, guiding, balanced" },
+  {
+    id: "example-first",
+    label: "Examples first",
+    blurb: "Every idea opens with a concrete case",
+  },
+];
+
+const STATUS_META: Record<ModuleStatus, { label: string; cls: string }> = {
+  explored: {
+    label: "Explored",
+    cls: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/30",
+  },
+  shaky: {
+    label: "Shaky",
+    cls: "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/30",
+  },
+  solid: {
+    label: "Solid",
+    cls: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/30",
+  },
+};
+
+export default function JourneyPage() {
+  const [journey, setJourney] = useState<Journey | null>(null);
+  const [streak, setStreak] = useState(0);
+  const [sheets, setSheets] = useState<{ module: string; count: number }[]>([]);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const refresh = () => {
+    setJourney(loadJourney());
+    setStreak(getStreak());
+    const found: { module: string; count: number }[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith("question-sheet:")) {
+        try {
+          const parsed = JSON.parse(localStorage.getItem(key) || "[]");
+          if (Array.isArray(parsed) && parsed.length) {
+            found.push({
+              module: key.replace("question-sheet:", ""),
+              count: parsed.length,
+            });
+          }
+        } catch {
+          /* skip corrupt sheet */
+        }
+      }
+    }
+    setSheets(found.sort((a, b) => b.count - a.count));
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleExport = () => {
+    const blob = new Blob([exportAllData()], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `beyond-syllabus-journey-${new Date().toISOString().slice(0, 10)}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast.success("Journey exported");
+  };
+
+  const handleImport = async (file: File) => {
+    try {
+      const { imported } = importAllData(await file.text());
+      refresh();
+      toast.success(`Imported ${imported} item(s)`);
+    } catch (e: any) {
+      toast.error(e?.message || "Import failed");
+    }
+  };
+
+  const modules = journey ? Object.entries(journey.modules) : [];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-mint-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-800">
+      <header className="flex items-center justify-between px-4 py-3 border-b border-border/50 sticky top-0 z-20 bg-background/70 backdrop-blur-sm">
+        <div className="flex items-center gap-2">
+          <Map className="h-5 w-5 text-primary" />
+          <h1 className="font-semibold">My Journey</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button asChild variant="ghost" size="sm">
+            <Link href="/select">Find a syllabus</Link>
+          </Button>
+          <ThemeToggle />
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto p-4 space-y-6">
+        {/* Privacy note + streak */}
+        <section className="grid sm:grid-cols-3 gap-4">
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-4 text-center">
+            <Flame
+              className={`h-7 w-7 mx-auto mb-1 ${streak > 0 ? "text-orange-500" : "text-muted-foreground"}`}
+            />
+            <p className="text-3xl font-bold">{streak}</p>
+            <p className="text-xs text-muted-foreground">day streak</p>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-4 text-center">
+            <Sparkles className="h-7 w-7 mx-auto mb-1 text-primary" />
+            <p className="text-3xl font-bold">{modules.length}</p>
+            <p className="text-xs text-muted-foreground">modules touched</p>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-4 text-center">
+            <ListChecks className="h-7 w-7 mx-auto mb-1 text-primary" />
+            <p className="text-3xl font-bold">
+              {sheets.reduce((n, s) => n + s.count, 0)}
+            </p>
+            <p className="text-xs text-muted-foreground">questions collected</p>
+          </div>
+        </section>
+
+        <p className="text-xs text-muted-foreground text-center">
+          Your journey lives on this device only. No account, no tracking.
+          Export it anytime; it is yours.
+        </p>
+
+        {/* Delivery mode */}
+        <section className="rounded-2xl border border-border/60 bg-background/70 p-4 space-y-3">
+          <h2 className="font-semibold text-sm">How should the AI talk to you?</h2>
+          <div className="grid sm:grid-cols-3 gap-2">
+            {MODES.map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => {
+                  setDeliveryMode(m.id);
+                  refresh();
+                  toast.success(`Delivery mode: ${m.label}`);
+                }}
+                className={`rounded-xl border px-3 py-2 text-left transition-colors ${
+                  journey?.deliveryMode === m.id
+                    ? "border-primary bg-primary/10"
+                    : "border-border/60 hover:bg-muted"
+                }`}
+              >
+                <p className="text-sm font-medium">{m.label}</p>
+                <p className="text-xs text-muted-foreground">{m.blurb}</p>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {/* Modules */}
+        <section className="rounded-2xl border border-border/60 bg-background/70 p-4 space-y-3">
+          <h2 className="font-semibold text-sm">Modules</h2>
+          {!modules.length && (
+            <p className="text-sm text-muted-foreground">
+              Nothing yet. Open a module and hit{" "}
+              <span className="text-primary font-medium">
+                Brainstorm before class
+              </span>{" "}
+              to start your journey.
+            </p>
+          )}
+          <ul className="space-y-2">
+            {modules
+              .sort(
+                (a, b) =>
+                  (b[1].lastActivity || "").localeCompare(a[1].lastActivity || "")
+              )
+              .map(([title, p]) => (
+                <li
+                  key={title}
+                  className="flex flex-wrap items-center gap-2 rounded-xl border border-border/50 px-3 py-2"
+                >
+                  <span className="flex-1 min-w-[12rem] text-sm font-medium">
+                    {title}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {p.brainstormSessions}× brainstormed ·{" "}
+                    {p.questionsCollected} questions
+                  </span>
+                  <div className="flex gap-1">
+                    {(Object.keys(STATUS_META) as ModuleStatus[]).map((s) => (
+                      <button
+                        key={s}
+                        type="button"
+                        onClick={() => {
+                          setModuleStatus(title, s);
+                          refresh();
+                        }}
+                        className={`text-[11px] px-2 py-0.5 rounded-full border transition-colors ${
+                          p.status === s
+                            ? STATUS_META[s].cls
+                            : "border-border/50 text-muted-foreground hover:bg-muted"
+                        }`}
+                      >
+                        {STATUS_META[s].label}
+                      </button>
+                    ))}
+                  </div>
+                </li>
+              ))}
+          </ul>
+        </section>
+
+        {/* Question sheets */}
+        <section className="rounded-2xl border border-border/60 bg-background/70 p-4 space-y-3">
+          <h2 className="font-semibold text-sm">Question Sheets</h2>
+          {!sheets.length && (
+            <p className="text-sm text-muted-foreground">
+              No sheets yet. Every brainstorm builds one.
+            </p>
+          )}
+          <ul className="space-y-1">
+            {sheets.map((s) => (
+              <li key={s.module} className="text-sm flex justify-between gap-2">
+                <span className="truncate">{s.module}</span>
+                <span className="text-muted-foreground shrink-0">
+                  {s.count} question{s.count === 1 ? "" : "s"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Data portability */}
+        <section className="flex flex-wrap gap-2 justify-center pb-8">
+          <Button variant="outline" size="sm" onClick={handleExport}>
+            <Download className="h-4 w-4 mr-1" /> Export my data
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fileRef.current?.click()}
+          >
+            <Upload className="h-4 w-4 mr-1" /> Import
+          </Button>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="application/json"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) handleImport(f);
+              e.target.value = "";
+            }}
+          />
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/lib/journey.ts
+++ b/apps/web/src/lib/journey.ts
@@ -1,0 +1,179 @@
+"use client";
+
+/**
+ * The Journey store: local-first continuity for Beyond Syllabus.
+ *
+ * Principles (docs/VISION.md): learning never requires an account, so the
+ * journey lives on the device. Everything is exportable/importable JSON,
+ * and the shape is deliberately sync-ready so future lightweight accounts
+ * or μLearn Karma interop can attach without a rewrite.
+ */
+
+export type ModuleStatus = "explored" | "shaky" | "solid";
+
+export type DeliveryMode = "peer" | "mentor" | "example-first";
+
+export interface ModuleProgress {
+  status: ModuleStatus;
+  brainstormSessions: number;
+  questionsCollected: number;
+  lastActivity: string; // ISO date
+}
+
+export interface Journey {
+  version: 1;
+  deliveryMode: DeliveryMode;
+  /** keyed by module title (same key the Question Sheet uses) */
+  modules: Record<string, ModuleProgress>;
+  /** YYYY-MM-DD days with any learning activity, for streaks */
+  activeDays: string[];
+}
+
+const KEY = "journey:v1";
+
+const EMPTY: Journey = {
+  version: 1,
+  deliveryMode: "mentor",
+  modules: {},
+  activeDays: [],
+};
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+export function loadJourney(): Journey {
+  if (!isBrowser()) return EMPTY;
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return { ...EMPTY };
+    const parsed = JSON.parse(raw);
+    if (parsed?.version !== 1) return { ...EMPTY };
+    return { ...EMPTY, ...parsed, modules: parsed.modules ?? {} };
+  } catch {
+    return { ...EMPTY };
+  }
+}
+
+function saveJourney(j: Journey): void {
+  if (!isBrowser()) return;
+  localStorage.setItem(KEY, JSON.stringify(j));
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function touchModule(j: Journey, moduleTitle: string): ModuleProgress {
+  const existing = j.modules[moduleTitle];
+  const entry: ModuleProgress = existing ?? {
+    status: "explored",
+    brainstormSessions: 0,
+    questionsCollected: 0,
+    lastActivity: today(),
+  };
+  entry.lastActivity = today();
+  j.modules[moduleTitle] = entry;
+  if (!j.activeDays.includes(today())) j.activeDays.push(today());
+  return entry;
+}
+
+export function recordBrainstormSession(moduleTitle: string): void {
+  if (!moduleTitle) return;
+  const j = loadJourney();
+  const entry = touchModule(j, moduleTitle);
+  entry.brainstormSessions += 1;
+  saveJourney(j);
+}
+
+export function recordQuestionCollected(moduleTitle: string): void {
+  if (!moduleTitle) return;
+  const j = loadJourney();
+  const entry = touchModule(j, moduleTitle);
+  entry.questionsCollected += 1;
+  saveJourney(j);
+}
+
+export function setModuleStatus(
+  moduleTitle: string,
+  status: ModuleStatus
+): void {
+  if (!moduleTitle) return;
+  const j = loadJourney();
+  const entry = touchModule(j, moduleTitle);
+  entry.status = status;
+  saveJourney(j);
+}
+
+export function getModuleStatus(moduleTitle: string): ModuleStatus | null {
+  const j = loadJourney();
+  return j.modules[moduleTitle]?.status ?? null;
+}
+
+export function setDeliveryMode(mode: DeliveryMode): void {
+  const j = loadJourney();
+  j.deliveryMode = mode;
+  saveJourney(j);
+}
+
+export function getDeliveryMode(): DeliveryMode {
+  return loadJourney().deliveryMode;
+}
+
+/** Consecutive active days ending today or yesterday */
+export function getStreak(): number {
+  const days = new Set(loadJourney().activeDays);
+  if (!days.size) return 0;
+  const d = new Date();
+  // A streak survives if yesterday was active even when today isn't yet
+  if (!days.has(d.toISOString().slice(0, 10))) {
+    d.setDate(d.getDate() - 1);
+    if (!days.has(d.toISOString().slice(0, 10))) return 0;
+  }
+  let streak = 0;
+  while (days.has(d.toISOString().slice(0, 10))) {
+    streak += 1;
+    d.setDate(d.getDate() - 1);
+  }
+  return streak;
+}
+
+/** Everything Beyond Syllabus keeps on this device, as portable JSON */
+export function exportAllData(): string {
+  const dump: Record<string, unknown> = {};
+  if (isBrowser()) {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      if (key === KEY || key.startsWith("question-sheet:")) {
+        try {
+          dump[key] = JSON.parse(localStorage.getItem(key) || "null");
+        } catch {
+          dump[key] = localStorage.getItem(key);
+        }
+      }
+    }
+  }
+  return JSON.stringify(
+    { exportedAt: new Date().toISOString(), app: "beyond-syllabus", data: dump },
+    null,
+    2
+  );
+}
+
+/** Merge an exported dump back in (imported device wins on conflicts) */
+export function importAllData(raw: string): { imported: number } {
+  const parsed = JSON.parse(raw);
+  const data = parsed?.data;
+  if (!data || typeof data !== "object") {
+    throw new Error("Not a Beyond Syllabus export file");
+  }
+  let imported = 0;
+  for (const [key, value] of Object.entries(data)) {
+    if (key === KEY || key.startsWith("question-sheet:")) {
+      localStorage.setItem(key, JSON.stringify(value));
+      imported += 1;
+    }
+  }
+  return { imported };
+}


### PR DESCRIPTION
Roadmap Phase 2, first slice: continuity and motivation **without a login wall**. The vision says no feature may require an account to learn, so the journey is local-first: it lives on the device, exports as JSON, and its shape is deliberately sync-ready for future lightweight accounts and μLearn Karma interop.

## What's new

- **`/journey` dashboard**: day streak, modules touched, questions collected, per-module status, question-sheet inventory, and data export/import. The page says it plainly: *'Your journey lives on this device only. No account, no tracking. Export it anytime; it is yours.'*
- **Foundation check v1** (vision moment 3): every module accordion asks *'Where do you stand on this module?'* — Shaky / Getting there / Solid — one honest tap that feeds the journey
- **Progress & streaks** (issue #18): brainstorm sessions and collected questions recorded automatically; streaks computed from active days. Deliberately no leaderboards, per the movement's anti-gamification-of-the-wrong-things stance
- **Delivery modes** (issue #11): peer / mentor / example-first, chosen once on /journey, wired into the brainstorm voice
- **Bug fix**: subject-page deep links 404'd after the payload migration (no loading state on the old whole-dataset read). Now uses `useUniversityData` with a spinner; also fixes a pre-existing flash-of-error.

## Deferred within Phase 2

Exam runway (#14) and PYQ integration (#16) are the next slice; server-side accounts deserve a maintainer decision on auth provider before anyone writes code.

## Verification

Build, lint green. Browser-tested: module status set on the subject page appears on /journey; counts aggregate across sessions; delivery mode persists; deep links load clean.

Prepared with Deepu S. Nath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)