### PR TITLE
Exam runway: dates in, a prioritized revision plan out

### DIFF
--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/ExamRunwayCard.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/ExamRunwayCard.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  addExam,
+  daysUntil,
+  Exam,
+  ExamModule,
+  getExamForSubject,
+  removeExam,
+} from "@/lib/journey";
+import { CalendarClock, Trash2 } from "lucide-react";
+import { toast } from "react-hot-toast";
+
+export function ExamRunwayCard({
+  subjectName,
+  modules,
+}: {
+  subjectName: string;
+  modules: ExamModule[];
+}) {
+  const [exam, setExam] = useState<Exam | null>(null);
+  const [date, setDate] = useState("");
+
+  useEffect(() => {
+    setExam(getExamForSubject(subjectName));
+  }, [subjectName]);
+
+  const minDate = new Date(Date.now() + 86400000).toISOString().slice(0, 10);
+
+  const save = () => {
+    if (!date) return;
+    const saved = addExam(subjectName, date, modules);
+    setExam(saved);
+    toast.success("Exam added to your runway");
+  };
+
+  const remove = () => {
+    if (!exam) return;
+    removeExam(exam.id);
+    setExam(null);
+    toast("Removed from runway");
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-3 dark:bg-black/50 bg-white rounded-xl shadow-lg p-5">
+      <div className="flex items-center gap-2">
+        <CalendarClock className="h-5 w-5 text-primary" />
+        <h3 className="font-semibold">Exam Runway</h3>
+      </div>
+
+      {exam ? (
+        <>
+          <p className="text-sm">
+            Exam on <span className="font-medium">{exam.date}</span>:{" "}
+            <span className="font-bold text-primary">
+              {daysUntil(exam.date)} day{daysUntil(exam.date) === 1 ? "" : "s"}
+            </span>{" "}
+            to go.
+          </p>
+          <div className="flex gap-2">
+            <Button asChild size="sm" className="flex-1">
+              <Link href="/journey">View my plan</Link>
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={remove}
+              aria-label="Remove exam"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="text-xs text-muted-foreground">
+            Add your exam date and get a revision plan built from where you
+            actually stand, module by module.
+          </p>
+          <input
+            type="date"
+            min={minDate}
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="rounded-lg border border-border/60 bg-background px-2.5 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+          />
+          <Button size="sm" disabled={!date} onClick={save}>
+            Add to my runway
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/page.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { SyllabusSummary } from "./_components/SyllabusSummary";
 import { CourseModules } from "./_components/CourseModules";
+import { ExamRunwayCard } from "./_components/ExamRunwayCard";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import { AnimatedDiv } from "@/components/AnimatedDiv";
 
@@ -160,9 +161,13 @@ export default function SubjectPage({ params }: SubjectPageProps) {
                 />
               </div>
               <div className=" flex gap-5 w-full flex-col">
-                <div className="flex w-full justify-center gap-5 text-[25px]  dark:bg-black/50 items-center text-center rounded-xl h-[150px] shadow-lg">
-                  New feature <br /> Coming Soon
-                </div>
+                <ExamRunwayCard
+                  subjectName={capitalizeWords(subject.name)}
+                  modules={(subject.modules || []).map((m: any) => ({
+                    title: m.title || "",
+                    content: m.content || "",
+                  }))}
+                />
                 <div className="flex w-full justify-center gap-5 text-[25px]  dark:bg-black/50 items-center text-center rounded-xl h-[150px] shadow-lg">
                   New feature <br /> Coming Soon
                 </div>

--- a/apps/web/src/app/journey/page.tsx
+++ b/apps/web/src/app/journey/page.tsx
@@ -14,13 +14,20 @@ import {
   importAllData,
   setModuleStatus,
   ModuleStatus,
+  buildRunwayPlan,
+  daysUntil,
+  removeExam,
+  RunwayItem,
 } from "@/lib/journey";
 import {
+  BrainCircuit,
+  CalendarClock,
   Download,
   Flame,
   ListChecks,
   Map,
   Sparkles,
+  Trash2,
   Upload,
 } from "lucide-react";
 import { toast } from "react-hot-toast";
@@ -149,6 +156,106 @@ export default function JourneyPage() {
           Your journey lives on this device only. No account, no tracking.
           Export it anytime; it is yours.
         </p>
+
+        {/* Exam runway */}
+        {journey && journey.exams.length > 0 && (
+          <section className="rounded-2xl border border-border/60 bg-background/70 p-4 space-y-4">
+            <h2 className="font-semibold text-sm flex items-center gap-2">
+              <CalendarClock className="h-4 w-4 text-primary" /> Exam Runway
+            </h2>
+            {journey.exams
+              .slice()
+              .sort((a, b) => a.date.localeCompare(b.date))
+              .map((exam) => {
+                const days = daysUntil(exam.date);
+                const plan = buildRunwayPlan(exam);
+                return (
+                  <div
+                    key={exam.id}
+                    className="rounded-xl border border-border/50 p-3 space-y-2"
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium text-sm flex-1 min-w-[10rem]">
+                        {exam.subject}
+                      </span>
+                      <span
+                        className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
+                          days <= 3
+                            ? "bg-red-500/10 text-red-600 dark:text-red-400"
+                            : days <= 10
+                              ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                              : "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                        }`}
+                      >
+                        {days < 0
+                          ? "done"
+                          : days === 0
+                            ? "today"
+                            : `${days} day${days === 1 ? "" : "s"} left`}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          removeExam(exam.id);
+                          refresh();
+                        }}
+                        aria-label="Remove exam"
+                      >
+                        <Trash2 className="h-3.5 w-3.5 text-muted-foreground hover:text-destructive" />
+                      </button>
+                    </div>
+                    {days >= 0 && (
+                      <ol className="space-y-1.5">
+                        {plan.map((item: RunwayItem) => (
+                          <li
+                            key={item.module.title}
+                            className="flex flex-wrap items-center gap-2 text-sm"
+                          >
+                            <span className="text-xs text-muted-foreground w-20 shrink-0">
+                              {item.suggestedDate.slice(5)}
+                            </span>
+                            <span className="flex-1 min-w-[10rem]">
+                              {item.module.title}
+                            </span>
+                            <span
+                              className={`text-[11px] px-2 py-0.5 rounded-full border ${
+                                item.status
+                                  ? STATUS_META[item.status].cls
+                                  : "border-border/50 text-muted-foreground"
+                              }`}
+                            >
+                              {item.status
+                                ? STATUS_META[item.status].label
+                                : "Untouched"}
+                            </span>
+                            {item.action !== "light-review" ? (
+                              <Link
+                                href={`/brainstorm?title=${encodeURIComponent(item.module.title)}&content=${encodeURIComponent(item.module.content)}`}
+                                className="text-[11px] px-2 py-0.5 rounded-full border border-primary/40 text-primary hover:bg-primary/10 flex items-center gap-1"
+                              >
+                                <BrainCircuit className="h-3 w-3" />
+                                {item.action === "brainstorm"
+                                  ? "Brainstorm"
+                                  : "Revisit"}
+                              </Link>
+                            ) : (
+                              <span className="text-[11px] text-muted-foreground">
+                                light review
+                              </span>
+                            )}
+                          </li>
+                        ))}
+                      </ol>
+                    )}
+                    <p className="text-[11px] text-muted-foreground">
+                      Weakest modules first; the eve of the exam stays free for
+                      one light pass over everything.
+                    </p>
+                  </div>
+                );
+              })}
+          </section>
+        )}
 
         {/* Delivery mode */}
         <section className="rounded-2xl border border-border/60 bg-background/70 p-4 space-y-3">

--- a/apps/web/src/lib/journey.ts
+++ b/apps/web/src/lib/journey.ts
@@ -20,6 +20,19 @@ export interface ModuleProgress {
   lastActivity: string; // ISO date
 }
 
+export interface ExamModule {
+  title: string;
+  content: string;
+}
+
+export interface Exam {
+  id: string;
+  subject: string;
+  /** YYYY-MM-DD */
+  date: string;
+  modules: ExamModule[];
+}
+
 export interface Journey {
   version: 1;
   deliveryMode: DeliveryMode;
@@ -27,6 +40,8 @@ export interface Journey {
   modules: Record<string, ModuleProgress>;
   /** YYYY-MM-DD days with any learning activity, for streaks */
   activeDays: string[];
+  /** upcoming exams for the runway */
+  exams: Exam[];
 }
 
 const KEY = "journey:v1";
@@ -36,6 +51,7 @@ const EMPTY: Journey = {
   deliveryMode: "mentor",
   modules: {},
   activeDays: [],
+  exams: [],
 };
 
 function isBrowser(): boolean {
@@ -49,7 +65,12 @@ export function loadJourney(): Journey {
     if (!raw) return { ...EMPTY };
     const parsed = JSON.parse(raw);
     if (parsed?.version !== 1) return { ...EMPTY };
-    return { ...EMPTY, ...parsed, modules: parsed.modules ?? {} };
+    return {
+      ...EMPTY,
+      ...parsed,
+      modules: parsed.modules ?? {},
+      exams: parsed.exams ?? [],
+    };
   } catch {
     return { ...EMPTY };
   }
@@ -118,6 +139,91 @@ export function setDeliveryMode(mode: DeliveryMode): void {
 
 export function getDeliveryMode(): DeliveryMode {
   return loadJourney().deliveryMode;
+}
+
+export function addExam(subject: string, date: string, modules: ExamModule[]): Exam {
+  const j = loadJourney();
+  const exam: Exam = {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    subject,
+    date,
+    modules,
+  };
+  // One exam per subject: replacing beats duplicating
+  j.exams = [...j.exams.filter((e) => e.subject !== subject), exam];
+  saveJourney(j);
+  return exam;
+}
+
+export function removeExam(id: string): void {
+  const j = loadJourney();
+  j.exams = j.exams.filter((e) => e.id !== id);
+  saveJourney(j);
+}
+
+export function getExamForSubject(subject: string): Exam | null {
+  return loadJourney().exams.find((e) => e.subject === subject) ?? null;
+}
+
+export function daysUntil(dateISO: string): number {
+  const target = new Date(`${dateISO}T00:00:00`);
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return Math.round((target.getTime() - now.getTime()) / 86400000);
+}
+
+export interface RunwayItem {
+  module: ExamModule;
+  status: ModuleStatus | null;
+  /** YYYY-MM-DD suggested study date */
+  suggestedDate: string;
+  action: "brainstorm" | "revisit" | "light-review";
+}
+
+/**
+ * The revision plan: weakest modules first, spread across the days left,
+ * with the final day reserved for a light pass over everything.
+ */
+export function buildRunwayPlan(exam: Exam): RunwayItem[] {
+  const j = loadJourney();
+  const priority = (s: ModuleStatus | null): number =>
+    s === "shaky" ? 0 : s === null ? 1 : s === "explored" ? 2 : 3;
+
+  const ordered = [...exam.modules].sort(
+    (a, b) =>
+      priority(j.modules[a.title]?.status ?? null) -
+      priority(j.modules[b.title]?.status ?? null)
+  );
+
+  const totalDays = Math.max(daysUntil(exam.date), 1);
+  // Study days exclude the exam day itself and reserve the eve for review
+  const studyDays = Math.max(totalDays - 1, 1);
+  const start = new Date();
+  start.setHours(0, 0, 0, 0);
+
+  return ordered.map((module, i) => {
+    const status = j.modules[module.title]?.status ?? null;
+    const offset =
+      ordered.length <= 1
+        ? 0
+        : Math.min(
+            Math.floor((i * studyDays) / ordered.length),
+            studyDays - 1
+          );
+    const d = new Date(start);
+    d.setDate(d.getDate() + offset);
+    return {
+      module,
+      status,
+      suggestedDate: d.toISOString().slice(0, 10),
+      action:
+        status === "solid"
+          ? "light-review"
+          : status === null
+            ? "brainstorm"
+            : "revisit",
+    };
+  });
 }
 
 /** Consecutive active days ending today or yesterday */


### PR DESCRIPTION
Closes the loop on issue #14 using the journey layer from #83.

## What's new

- **Add an exam from any subject page** (the runway card replaces one 'Coming Soon' placeholder): pick the date, get a countdown
- **The plan, on /journey**: modules ordered weakest-first (Shaky → Untouched → Getting there → Solid), suggested study dates spread across the days remaining, and the exam eve deliberately reserved for one light pass over everything
- **Every plan item is actionable**: Untouched modules get a one-tap **Brainstorm** link (opens the guided brainstorm with that module's real content), shaky ones get **Revisit**, solid ones get a light review
- The store stays local-first and export-compatible; one exam per subject (re-adding replaces)

## Why this design

The plan is honest scheduling, not AI theater: it reads the student's own foundation-check statuses, so keeping the plan good is the same act as being honest about where you stand. That is the motivation loop issues #14 and #18 were both circling.

## Verification

Build and lint green. Browser-tested: exam creation, countdown, 4-module plan across 14 days, and live re-prioritization (marking a module Solid moved it to the final slot as light review).

Prepared with Deepu S. Nath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)