### PR TITLE
Teacher view: classroom codes and anonymous question aggregation

### DIFF
--- a/apps/server/src/routes/classroom/index.ts
+++ b/apps/server/src/routes/classroom/index.ts
@@ -1,0 +1,181 @@
+import { Redis } from "@upstash/redis";
+import { ORPCError } from "@orpc/client";
+import { randomBytes } from "node:crypto";
+import { publicProcedure } from "../../lib/orpc";
+import { env } from "../../config/env";
+
+/**
+ * Classrooms: the flipped classroom's teacher half.
+ *
+ * A teacher creates a classroom and shares its code. Students submit the
+ * questions from their Question Sheets anonymously: no names, no ids,
+ * questions only. The teacher sees the aggregate per module.
+ *
+ * Storage: Upstash Redis when real credentials are configured (same infra
+ * as share links), otherwise an in-process memory store so local dev and
+ * credential-less self-hosting still work (single process, non-durable).
+ */
+
+const TTL_SECONDS = 60 * 60 * 24 * 60; // 60 days, refreshed on activity
+const MAX_SUBMISSIONS = 500;
+const MAX_QUESTIONS_PER_SUBMISSION = 20;
+const MAX_QUESTION_LENGTH = 300;
+
+interface ClassroomMeta {
+  name: string;
+  createdAt: number;
+}
+
+interface Submission {
+  module: string;
+  questions: string[];
+  at: number;
+}
+
+interface ClassroomStore {
+  getMeta(code: string): Promise<ClassroomMeta | null>;
+  setMeta(code: string, meta: ClassroomMeta): Promise<void>;
+  addSubmission(code: string, sub: Submission): Promise<number>;
+  getSubmissions(code: string): Promise<Submission[]>;
+}
+
+class RedisStore implements ClassroomStore {
+  private redis = new Redis({
+    url: env.UPSTASH_REDIS_URL,
+    token: env.UPSTASH_REDIS_TOKEN,
+  });
+
+  async getMeta(code: string) {
+    return (await this.redis.get<ClassroomMeta>(`class:${code}`)) ?? null;
+  }
+  async setMeta(code: string, meta: ClassroomMeta) {
+    await this.redis.set(`class:${code}`, meta, { ex: TTL_SECONDS });
+  }
+  async addSubmission(code: string, sub: Submission) {
+    const key = `class:${code}:subs`;
+    const len = await this.redis.rpush(key, JSON.stringify(sub));
+    await this.redis.ltrim(key, -MAX_SUBMISSIONS, -1);
+    await this.redis.expire(key, TTL_SECONDS);
+    await this.redis.expire(`class:${code}`, TTL_SECONDS);
+    return Math.min(len, MAX_SUBMISSIONS);
+  }
+  async getSubmissions(code: string) {
+    const raw = await this.redis.lrange(`class:${code}:subs`, 0, -1);
+    return raw
+      .map((r) => {
+        try {
+          return typeof r === "string" ? (JSON.parse(r) as Submission) : (r as Submission);
+        } catch {
+          return null;
+        }
+      })
+      .filter((s): s is Submission => !!s);
+  }
+}
+
+class MemoryStore implements ClassroomStore {
+  private meta = new Map<string, { v: ClassroomMeta; exp: number }>();
+  private subs = new Map<string, { v: Submission[]; exp: number }>();
+
+  private alive<T>(entry: { v: T; exp: number } | undefined): T | null {
+    if (!entry) return null;
+    if (Date.now() > entry.exp) return null;
+    return entry.v;
+  }
+  async getMeta(code: string) {
+    return this.alive(this.meta.get(code));
+  }
+  async setMeta(code: string, meta: ClassroomMeta) {
+    this.meta.set(code, { v: meta, exp: Date.now() + TTL_SECONDS * 1000 });
+  }
+  async addSubmission(code: string, sub: Submission) {
+    const entry = this.subs.get(code);
+    const list = this.alive(entry) ?? [];
+    list.push(sub);
+    while (list.length > MAX_SUBMISSIONS) list.shift();
+    this.subs.set(code, { v: list, exp: Date.now() + TTL_SECONDS * 1000 });
+    return list.length;
+  }
+  async getSubmissions(code: string) {
+    return this.alive(this.subs.get(code)) ?? [];
+  }
+}
+
+// Real Upstash tokens are long; placeholders and empty configs are not.
+const store: ClassroomStore =
+  env.UPSTASH_REDIS_TOKEN && env.UPSTASH_REDIS_TOKEN.length > 30
+    ? new RedisStore()
+    : new MemoryStore();
+
+function generateCode(): string {
+  // 6 chars, unambiguous alphabet, uppercase for easy dictation in a room
+  const alphabet = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+  const bytes = randomBytes(6);
+  return Array.from(bytes, (b) => alphabet[b % alphabet.length]).join("");
+}
+
+const sanitizeQuestions = (questions: unknown): string[] => {
+  if (!Array.isArray(questions)) return [];
+  return questions
+    .filter((q): q is string => typeof q === "string")
+    .map((q) => q.trim())
+    .filter((q) => q.length > 3 && q.length <= MAX_QUESTION_LENGTH)
+    .slice(0, MAX_QUESTIONS_PER_SUBMISSION);
+};
+
+export const classroomRoutes = {
+  create: publicProcedure.handler(async ({ input }) => {
+    const { name } = (input ?? {}) as { name?: string };
+    const trimmed = (name ?? "").trim();
+    if (!trimmed || trimmed.length > 80) {
+      throw new ORPCError("Invalid Input", {
+        message: "Classroom name is required (max 80 characters)",
+      });
+    }
+    let code = generateCode();
+    // Regenerate on the (unlikely) collision
+    while (await store.getMeta(code)) code = generateCode();
+    await store.setMeta(code, { name: trimmed, createdAt: Date.now() });
+    return { code, name: trimmed };
+  }),
+
+  submit: publicProcedure.handler(async ({ input }) => {
+    const { code, module, questions } = (input ?? {}) as {
+      code?: string;
+      module?: string;
+      questions?: unknown;
+    };
+    const normalizedCode = (code ?? "").trim().toUpperCase();
+    const meta = normalizedCode ? await store.getMeta(normalizedCode) : null;
+    if (!meta) {
+      throw new ORPCError("Not Found", {
+        message: "That classroom code doesn't exist (or has expired)",
+      });
+    }
+    const clean = sanitizeQuestions(questions);
+    if (!clean.length) {
+      throw new ORPCError("Invalid Input", {
+        message: "Nothing to send: the sheet has no valid questions",
+      });
+    }
+    const count = await store.addSubmission(normalizedCode, {
+      module: (module ?? "General").trim().slice(0, 200) || "General",
+      questions: clean,
+      at: Date.now(),
+    });
+    return { ok: true, submissions: count };
+  }),
+
+  get: publicProcedure.handler(async ({ input }) => {
+    const { code } = (input ?? {}) as { code?: string };
+    const normalizedCode = (code ?? "").trim().toUpperCase();
+    const meta = normalizedCode ? await store.getMeta(normalizedCode) : null;
+    if (!meta) {
+      throw new ORPCError("Not Found", {
+        message: "That classroom code doesn't exist (or has expired)",
+      });
+    }
+    const submissions = await store.getSubmissions(normalizedCode);
+    return { name: meta.name, createdAt: meta.createdAt, submissions };
+  }),
+};

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -3,6 +3,7 @@ import type { RouterClient } from "@orpc/server";
 import path from "node:path";
 import { file } from "bun";
 import { shareRoutes } from "./share";
+import { classroomRoutes } from "./classroom";
 
 // Parse the syllabus dataset once per process instead of on every request.
 let syllabusCache: Record<string, unknown> | null = null;
@@ -41,6 +42,7 @@ export const appRouter = {
     return { [university]: slice };
   }),
   share: shareRoutes,
+  classroom: classroomRoutes,
 };
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/src/app/brainstorm/page.tsx
+++ b/apps/web/src/app/brainstorm/page.tsx
@@ -23,10 +23,12 @@ import {
   Lightbulb,
   ListChecks,
   Plus,
+  Send,
   Sparkles,
   Trash2,
 } from "lucide-react";
 import { toast } from "react-hot-toast";
+import { orpc } from "@/lib/orpc";
 
 type SheetQuestion = {
   id: string;
@@ -50,6 +52,8 @@ export default function BrainstormPage() {
   const [sheet, setSheet] = useState<SheetQuestion[]>([]);
   const [ownQuestion, setOwnQuestion] = useState("");
   const [model, setModel] = useState("openai/gpt-oss-120b");
+  const [classCode, setClassCode] = useState("");
+  const [sending, setSending] = useState(false);
   const startedStages = useRef<Set<string>>(new Set());
   const endRef = useRef<HTMLDivElement>(null);
 
@@ -136,6 +140,29 @@ export default function BrainstormPage() {
       { id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`, text: trimmed, source },
     ]);
     recordQuestionCollected(moduleTitle);
+  };
+
+  useEffect(() => {
+    setClassCode(localStorage.getItem("last-class-code") || "");
+  }, []);
+
+  const sendToClass = async () => {
+    const code = classCode.trim().toUpperCase();
+    if (!code || !sheet.length || sending) return;
+    setSending(true);
+    try {
+      await orpc.classroom.submit.call({
+        code,
+        module: moduleTitle,
+        questions: sheet.map((q) => q.text),
+      });
+      localStorage.setItem("last-class-code", code);
+      toast.success("Sent to your class, anonymously");
+    } catch (e: any) {
+      toast.error(e?.message || "Could not send to class");
+    } finally {
+      setSending(false);
+    }
   };
 
   const exportSheet = () => {
@@ -340,6 +367,29 @@ export default function BrainstormPage() {
                 </li>
               )}
             </ul>
+
+            {sheet.length > 0 && (
+              <div className="flex gap-2 items-center border-t border-border/50 pt-3">
+                <input
+                  value={classCode}
+                  onChange={(e) => setClassCode(e.target.value.toUpperCase())}
+                  placeholder="Class code"
+                  maxLength={6}
+                  className="w-24 text-xs font-mono tracking-widest rounded-lg border border-border/60 bg-background px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/40"
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-8 flex-1"
+                  disabled={classCode.trim().length < 6 || sending}
+                  onClick={sendToClass}
+                  title="Send your questions to your teacher, anonymously"
+                >
+                  <Send className="h-3.5 w-3.5 mr-1" />
+                  {sending ? "Sending…" : "Send to class"}
+                </Button>
+              </div>
+            )}
 
             <form
               className="flex gap-2"

--- a/apps/web/src/app/teach/page.tsx
+++ b/apps/web/src/app/teach/page.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { orpc } from "@/lib/orpc";
+import {
+  GraduationCap,
+  ListChecks,
+  Plus,
+  RefreshCw,
+  Users,
+} from "lucide-react";
+import { toast } from "react-hot-toast";
+
+type SavedClassroom = { code: string; name: string };
+
+type Submission = { module: string; questions: string[]; at: number };
+
+type AggregatedModule = {
+  module: string;
+  total: number;
+  questions: { text: string; count: number }[];
+};
+
+function aggregate(submissions: Submission[]): AggregatedModule[] {
+  const byModule = new Map<string, Map<string, number>>();
+  for (const sub of submissions) {
+    const mod = byModule.get(sub.module) ?? new Map<string, number>();
+    for (const q of sub.questions) {
+      const key = q.trim();
+      mod.set(key, (mod.get(key) ?? 0) + 1);
+    }
+    byModule.set(sub.module, mod);
+  }
+  return Array.from(byModule.entries())
+    .map(([module, qs]) => ({
+      module,
+      total: Array.from(qs.values()).reduce((a, b) => a + b, 0),
+      questions: Array.from(qs.entries())
+        .map(([text, count]) => ({ text, count }))
+        .sort((a, b) => b.count - a.count),
+    }))
+    .sort((a, b) => b.total - a.total);
+}
+
+const SAVED_KEY = "classrooms:v1";
+
+export default function TeachPage() {
+  const [saved, setSaved] = useState<SavedClassroom[]>([]);
+  const [newName, setNewName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [codeInput, setCodeInput] = useState("");
+  const [active, setActive] = useState<{
+    code: string;
+    name: string;
+    submissions: Submission[];
+  } | null>(null);
+  const [loadingView, setLoadingView] = useState(false);
+
+  useEffect(() => {
+    try {
+      setSaved(JSON.parse(localStorage.getItem(SAVED_KEY) || "[]"));
+    } catch {
+      /* start fresh */
+    }
+  }, []);
+
+  const persist = (list: SavedClassroom[]) => {
+    setSaved(list);
+    localStorage.setItem(SAVED_KEY, JSON.stringify(list));
+  };
+
+  const createClassroom = async () => {
+    if (!newName.trim() || creating) return;
+    setCreating(true);
+    try {
+      const result = (await orpc.classroom.create.call({
+        name: newName.trim(),
+      })) as { code: string; name: string };
+      persist([...saved, result]);
+      setNewName("");
+      toast.success(`Classroom created: ${result.code}`);
+      openClassroom(result.code);
+    } catch (e: any) {
+      toast.error(e?.message || "Could not create classroom");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const openClassroom = async (code: string) => {
+    const normalized = code.trim().toUpperCase();
+    if (!normalized) return;
+    setLoadingView(true);
+    try {
+      const result = (await orpc.classroom.get.call({
+        code: normalized,
+      })) as { name: string; submissions: Submission[] };
+      setActive({ code: normalized, ...result });
+    } catch (e: any) {
+      toast.error(e?.message || "Could not open classroom");
+    } finally {
+      setLoadingView(false);
+    }
+  };
+
+  const modules = active ? aggregate(active.submissions) : [];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-mint-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-800">
+      <header className="flex items-center justify-between px-4 py-3 border-b border-border/50 sticky top-0 z-20 bg-background/70 backdrop-blur-sm">
+        <div className="flex items-center gap-2">
+          <GraduationCap className="h-5 w-5 text-primary" />
+          <h1 className="font-semibold">Teach</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button asChild variant="ghost" size="sm">
+            <Link href="/select">Syllabus</Link>
+          </Button>
+          <ThemeToggle />
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto p-4 space-y-6">
+        <p className="text-sm text-muted-foreground text-center max-w-2xl mx-auto">
+          The flipped classroom's other half: students brainstorm before class
+          and send their questions in, <strong>anonymously</strong>: no names,
+          no accounts, questions only. You walk in knowing exactly where the
+          class actually is.
+        </p>
+
+        {/* Create + open */}
+        <section className="grid sm:grid-cols-2 gap-4">
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-4 space-y-3">
+            <h2 className="font-semibold text-sm">Create a classroom</h2>
+            <input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="e.g. S3 AI&DS · Economics"
+              maxLength={80}
+              className="w-full rounded-lg border border-border/60 bg-background px-2.5 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+            <Button
+              size="sm"
+              onClick={createClassroom}
+              disabled={!newName.trim() || creating}
+            >
+              <Plus className="h-4 w-4 mr-1" /> Create & get code
+            </Button>
+          </div>
+
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-4 space-y-3">
+            <h2 className="font-semibold text-sm">Open a classroom</h2>
+            <input
+              value={codeInput}
+              onChange={(e) => setCodeInput(e.target.value.toUpperCase())}
+              placeholder="Classroom code"
+              maxLength={6}
+              className="w-full rounded-lg border border-border/60 bg-background px-2.5 py-1.5 text-sm font-mono tracking-widest focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => openClassroom(codeInput)}
+              disabled={codeInput.trim().length < 6 || loadingView}
+            >
+              Open
+            </Button>
+            {saved.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 pt-1">
+                {saved.map((c) => (
+                  <button
+                    key={c.code}
+                    type="button"
+                    onClick={() => openClassroom(c.code)}
+                    className="text-[11px] px-2 py-1 rounded-full border border-border/60 hover:bg-muted"
+                    title={c.name}
+                  >
+                    <span className="font-mono">{c.code}</span> · {c.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* Dashboard */}
+        {active && (
+          <section className="rounded-2xl border border-border/60 bg-background/70 p-4 space-y-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="font-semibold flex-1 min-w-[12rem]">
+                {active.name}{" "}
+                <span className="font-mono text-sm text-muted-foreground">
+                  ({active.code})
+                </span>
+              </h2>
+              <span className="text-xs text-muted-foreground flex items-center gap-1">
+                <Users className="h-3.5 w-3.5" /> {active.submissions.length}{" "}
+                submission{active.submissions.length === 1 ? "" : "s"}
+              </span>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => openClassroom(active.code)}
+                disabled={loadingView}
+              >
+                <RefreshCw
+                  className={`h-4 w-4 ${loadingView ? "animate-spin" : ""}`}
+                />
+              </Button>
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+              Students send questions from their Brainstorm sessions with your
+              code: <span className="font-mono font-semibold">{active.code}</span>.
+              Repeated questions rise to the top; those are your lecture's
+              first ten minutes.
+            </p>
+
+            {!modules.length && (
+              <p className="text-sm text-muted-foreground italic">
+                No questions yet. Share the code and give it a class-prep
+                cycle.
+              </p>
+            )}
+
+            {modules.map((m) => (
+              <div
+                key={m.module}
+                className="rounded-xl border border-border/50 p-3 space-y-2"
+              >
+                <h3 className="text-sm font-semibold flex items-center gap-2">
+                  <ListChecks className="h-4 w-4 text-primary" />
+                  {m.module}
+                  <span className="text-xs text-muted-foreground font-normal">
+                    {m.total} question{m.total === 1 ? "" : "s"}
+                  </span>
+                </h3>
+                <ol className="space-y-1.5">
+                  {m.questions.map((q) => (
+                    <li
+                      key={q.text}
+                      className="flex items-start gap-2 text-sm"
+                    >
+                      {q.count > 1 && (
+                        <span className="shrink-0 text-[11px] font-semibold px-1.5 py-0.5 rounded-full bg-primary/10 text-primary">
+                          ×{q.count}
+                        </span>
+                      )}
+                      <span>{q.text}</span>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            ))}
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
The flipped classroom's other half (roadmap Phase 3; the vision's teacher loop): students brainstorm before class, and the teacher walks in knowing where the class actually is.

## How it works

1. **Teacher** opens `/teach`, creates a classroom, gets a 6-character dictation-friendly code (unambiguous alphabet, no O/0/I/1)
2. **Students** tap **Send to class** on their Brainstorm Question Sheet and enter the code once (remembered for next time). Submissions carry **module + questions only**: no names, no ids, no accounts. Anonymity is the design, not a setting
3. **The dashboard** aggregates per module, counts duplicate questions and sorts them to the top. The UI says it plainly: *repeated questions are your lecture's first ten minutes*

## Engineering notes

- Storage rides the existing Upstash Redis (same pattern as share links) behind a small adapter, with an **in-process memory store fallback** when real credentials are absent, so local dev and credential-less self-hosting work out of the box. 60-day TTL, capped payloads and submission counts
- No AI calls: aggregation is honest counting. An optional AI theme-summary is an easy follow-up once classrooms see real volume

## Verification

Build and lint green. Full loop browser-tested on the memory store: classroom created → student sheet sent from the brainstorm page → dashboard showed the submission under the right module → a second submission aggregated to ×2 badges.

This is the feature the campus pilot (Track B) needs; it stays gated on the safeguarding policy per the Operating Thesis.

Prepared with Deepu S. Nath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)