### PR TITLE
PYQ integration: parse papers from WikiSyllabus, show them on the subject page

### DIFF
--- a/apps/server/src/routes/syllabus/generate.ts
+++ b/apps/server/src/routes/syllabus/generate.ts
@@ -51,6 +51,39 @@ async function readSyllabusData() {
               subjects: [],
             };
 
+            // Previous-year question papers: pyq/<subjectid>-<examyear>[-<session>].md
+            const pyqsBySubject: Record<
+              string,
+              { examYear: string; session: string | null; content: string }[]
+            > = {};
+            const pyqDir = path.join(semesterPath, "pyq");
+            if (
+              fs.existsSync(pyqDir) &&
+              (await fs.promises.lstat(pyqDir)).isDirectory()
+            ) {
+              const pyqFiles = await fs.promises.readdir(pyqDir);
+              for (const pyqFile of pyqFiles) {
+                const pyqMatch = pyqFile.match(
+                  /^([a-z0-9_]+)-(\d{4})(?:-([a-z]+))?\.md$/i
+                );
+                if (!pyqMatch) continue;
+                const [, subjectId, examYear, session] = pyqMatch;
+                const pyqContent = await fs.promises.readFile(
+                  path.join(pyqDir, pyqFile),
+                  "utf-8"
+                );
+                const { content: pyqBody } = matter(pyqContent);
+                (pyqsBySubject[subjectId] ??= []).push({
+                  examYear,
+                  session: session || null,
+                  content: pyqBody.trim(),
+                });
+              }
+              for (const list of Object.values(pyqsBySubject)) {
+                list.sort((a, b) => b.examYear.localeCompare(a.examYear));
+              }
+            }
+
             for (const subjectFile of subjectFiles) {
               if (subjectFile.endsWith(".md")) {
                 const subjectFilePath = path.join(semesterPath, subjectFile);
@@ -145,6 +178,7 @@ async function readSyllabusData() {
                   code: frontmatter.course_code || "N/A",
                   name: frontmatter.course_title || "N/A",
                   fullSyllabus: content.trim(),
+                  pyqs: pyqsBySubject[subjectFile.replace(".md", "")] || [],
                   modules: moduleItems,
                   university: frontmatter.university || "N/A",
                   program: frontmatter.branch || "N/A",

--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/PyqCard.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/PyqCard.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { FileQuestion, MessageSquareText } from "lucide-react";
+
+export interface Pyq {
+  examYear: string;
+  session: string | null;
+  content: string;
+}
+
+function label(p: Pyq): string {
+  const session = p.session
+    ? ` (${p.session[0].toUpperCase()}${p.session.slice(1)})`
+    : "";
+  return `${p.examYear}${session}`;
+}
+
+export function PyqCard({
+  subjectName,
+  pyqs,
+}: {
+  subjectName: string;
+  pyqs: Pyq[];
+}) {
+  const router = useRouter();
+
+  const discuss = (p: Pyq) => {
+    router.push(
+      `/chat?title=${encodeURIComponent(
+        `${subjectName} — PYQ ${label(p)}`
+      )}&content=${encodeURIComponent(
+        `Previous year question paper (${label(p)}) for ${subjectName}:\n\n${p.content}`
+      )}`
+    );
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-3 dark:bg-black/50 bg-white rounded-xl shadow-lg p-5">
+      <div className="flex items-center gap-2">
+        <FileQuestion className="h-5 w-5 text-primary" />
+        <h3 className="font-semibold">Previous Year Questions</h3>
+      </div>
+
+      {pyqs.length ? (
+        <ul className="space-y-2">
+          {pyqs.map((p) => (
+            <li key={label(p)}>
+              <details className="rounded-lg border border-border/50 px-3 py-2">
+                <summary className="text-sm font-medium cursor-pointer flex items-center justify-between gap-2">
+                  <span>{label(p)}</span>
+                </summary>
+                <pre className="mt-2 max-h-64 overflow-y-auto whitespace-pre-wrap text-xs text-muted-foreground font-sans">
+                  {p.content}
+                </pre>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="mt-2 w-full border-primary/40 text-primary hover:bg-primary/10"
+                  onClick={() => discuss(p)}
+                >
+                  <MessageSquareText className="h-3.5 w-3.5 mr-1" />
+                  Work through it with AI
+                </Button>
+              </details>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <>
+          <p className="text-xs text-muted-foreground">
+            No papers for this subject yet. If you have a past paper your
+            university circulated, contributing it takes one markdown file,
+            and it lights up here for every student of this course.
+          </p>
+          <Button asChild size="sm" variant="outline">
+            <a
+              href="https://github.com/The-Purple-Movement/WikiSyllabus/blob/main/CONTRIBUTION.md"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Contribute a paper
+            </a>
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/page.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/page.tsx
@@ -6,6 +6,7 @@ import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { SyllabusSummary } from "./_components/SyllabusSummary";
 import { CourseModules } from "./_components/CourseModules";
 import { ExamRunwayCard } from "./_components/ExamRunwayCard";
+import { PyqCard } from "./_components/PyqCard";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import { AnimatedDiv } from "@/components/AnimatedDiv";
 
@@ -168,9 +169,10 @@ export default function SubjectPage({ params }: SubjectPageProps) {
                     content: m.content || "",
                   }))}
                 />
-                <div className="flex w-full justify-center gap-5 text-[25px]  dark:bg-black/50 items-center text-center rounded-xl h-[150px] shadow-lg">
-                  New feature <br /> Coming Soon
-                </div>
+                <PyqCard
+                  subjectName={capitalizeWords(subject.name)}
+                  pyqs={(subject as any).pyqs || []}
+                />
               </div>
             </div>
             <div className="flex w-full gap-5">


### PR DESCRIPTION
Closes issue #16's app half. Companion: [WikiSyllabus #192](https://github.com/The-Purple-Movement/WikiSyllabus/pull/192) defines the contribution format.

## The chain

1. Contributors drop `pyq/<subjectid>-<examyear>[-<session>].md` next to a semester's subjects in WikiSyllabus (validated by its CI)
2. `generate.ts` attaches papers to their subject in `syllabus.json` (newest first, session-aware) — flows automatically via the existing 6-hourly sync
3. The subject page's last 'Coming Soon' slot becomes the **Previous Year Questions** card: papers expand inline, and every paper has **Work through it with AI**, opening chat with the paper as context
4. **The empty state recruits**: subjects without papers show a one-file contribution pitch linking to the WikiSyllabus guide, so every gap a student hits is an invitation

## Verification

Fixture-tested end to end: generator output verified (two papers, sorted, session parsed, modules intact), browser-tested card render, inline expansion, and the AI handoff carrying the paper text. Committed `syllabus.json` untouched. Build and lint green.

Prepared with Deepu S. Nath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)