### PR TITLE
fix(server): allow Vercel per-deployment origins in CORS

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -36,7 +36,13 @@ const apiHandler = new OpenAPIHandler(appRouter, {
 
 const port = Number(process.env.PORT) || 3000;
 
-const allowedOrigins = env.CORS_ORIGIN;
+// Origins from CORS_ORIGIN env (stable domains), plus this project's
+// per-deployment Vercel URLs (beyond-syllabus-<hash>-deepusnaths-projects.vercel.app),
+// which change on every deploy and cannot be listed in the env var.
+const allowedOrigins: (string | RegExp)[] = [
+  ...env.CORS_ORIGIN,
+  /^https:\/\/beyond-syllabus-[a-z0-9]+-deepusnaths-projects\.vercel\.app$/,
+];
 
 const app = new Elysia()
   .use(

--- a/apps/server/src/routes/classroom/index.ts
+++ b/apps/server/src/routes/classroom/index.ts
@@ -26,7 +26,7 @@ interface ClassroomMeta {
   createdAt: number;
 }
 
-interface Submission {
+export interface Submission {
   module: string;
   questions: string[];
   at: number;


### PR DESCRIPTION
## Why

After every Vercel redeploy, the deployment gets a fresh URL like `beyond-syllabus-<hash>-deepusnaths-projects.vercel.app`. These cannot be listed in `CORS_ORIGIN` (they change each deploy), so opening the app on one of those URLs fails with a CORS error, which looks like an outage when it is not.

## What

- `apps/server/src/index.ts`: alongside the stable domains from `CORS_ORIGIN`, accept origins matching `^https://beyond-syllabus-[a-z0-9]+-deepusnaths-projects\.vercel\.app$` (scoped to the movement's Vercel team, so arbitrary `*.vercel.app` projects are still rejected)
- `apps/server/src/routes/classroom/index.ts`: export the `Submission` interface. `tsc -b` was failing with TS4023 because the private type leaked into `appRouter`'s public type

## Verified

- `bun run check-types` in `apps/server` passes (was failing before)
- Stable origin `beyond-syllabus-web-beta.vercel.app` confirmed working against the live Render API via preflight check

🤖 Generated with [Claude Code](https://claude.com/claude-code)