### PR TITLE
UX Milestone 1: Honest surface

### DIFF
--- a/apps/server/src/routes/classroom/index.ts
+++ b/apps/server/src/routes/classroom/index.ts
@@ -26,7 +26,7 @@ interface ClassroomMeta {
   createdAt: number;
 }
 
-interface Submission {
+export interface Submission {
   module: string;
   questions: string[];
   at: number;

--- a/apps/web/src/ai/flows/summarize-syllabus.ts
+++ b/apps/web/src/ai/flows/summarize-syllabus.ts
@@ -2,273 +2,61 @@
 
 import { ai } from "@/ai/ai";
 import {
-  createStandardizedPrompt,
-  validateStandardizedFormat,
-} from "@/ai/utils/prompt-builder";
-import { PersonaTemplates } from "@/ai/utils/standardized-format";
-import {
   SummarizeSyllabusInput,
   SummarizeSyllabusOutput,
-  WikiSyllabusAIFormat,
 } from "@/lib/types";
 
+/**
+ * One tight, human overview of a course. No section skeletons, no
+ * "Not specified" filler, no keyword blocklists (Phase 0 principle:
+ * we do not guess at intent with word lists; the input here is always
+ * syllabus text the app itself supplied).
+ */
 export async function summarizeSyllabus(
   input: SummarizeSyllabusInput
 ): Promise<SummarizeSyllabusOutput> {
-  return summarizeSyllabusFlow(input);
-}
-
-const summarizeSyllabusFlow = async (
-  input: SummarizeSyllabusInput
-): Promise<SummarizeSyllabusOutput> => {
-  // Input validation
   if (!input.syllabusText || input.syllabusText.trim().length < 10) {
     return {
       summary:
-        "The provided syllabus text is too short or empty to generate a meaningful summary. Please provide more detailed course content including learning objectives, topics covered, and course structure.",
+        "This subject's syllabus text is still empty on WikiSyllabus, so there is nothing to summarize yet.",
     };
-  }
-
-  // Content validation for educational material
-  const validateSyllabusContent = (text: string): boolean => {
-    const nonEducationalKeywords = [
-      "celebrity",
-      "entertainment",
-      "gossip",
-      "sports news",
-      "personal life",
-      "social media",
-      "gaming",
-      "movies",
-      "tv shows",
-      "fashion",
-      "lifestyle",
-      "politics",
-      "religion",
-      "dating",
-      "relationships",
-      "messi",
-      "ronaldo",
-    ];
-
-    const educationalKeywords = [
-      "course",
-      "syllabus",
-      "learning",
-      "objectives",
-      "curriculum",
-      "student",
-      "study",
-      "knowledge",
-      "skill",
-      "understand",
-      "analyze",
-      "concept",
-      "theory",
-      "assignment",
-      "exam",
-      "module",
-      "chapter",
-      "lesson",
-    ];
-
-    const textLower = text.toLowerCase();
-
-    const hasNonEducational = nonEducationalKeywords.some((keyword) =>
-      textLower.includes(keyword)
-    );
-
-    const hasEducational =
-      educationalKeywords.some((keyword) => textLower.includes(keyword)) ||
-      text.length > 100; // Allow longer texts that might be educational
-
-    return !hasNonEducational && hasEducational;
-  };
-
-  // Validate content is educational
-  if (!validateSyllabusContent(input.syllabusText)) {
-    return {
-      summary:
-        "The provided content doesn't appear to be educational syllabus material. Please provide academic course content including learning objectives, topics covered, assessment methods, and course structure for summarization.",
-    };
-  }
-
-  // Create standardized AI interaction format
-  const aiFormat: WikiSyllabusAIFormat = {
-    persona: {
-      ...PersonaTemplates.PROFESSOR,
-      role: "You are an expert academic curriculum analyst specializing in educational content summarization",
-      expertise: [
-        "Identifying core learning objectives",
-        "Skill development outcomes",
-        "Knowledge domains across various academic disciplines",
-      ],
-    },
-    task: {
-      action:
-        "Analyze the following syllabus and create a comprehensive summary",
-      objectives: [
-        "Identify the subject area and academic level",
-        "Extract core learning objectives and outcomes",
-        "Categorize knowledge domains and skill areas",
-        "Highlight practical applications and assessments",
-      ],
-      deliverables: [
-        "Course overview with subject area and level",
-        "4-6 primary learning goals focusing on student outcomes",
-        "Main topics and concepts with theoretical foundations",
-        "Skills development areas and assessment methods",
-      ],
-      successCriteria: [
-        "Summary captures the essence of what students will learn",
-        "Uses clear, concise language suitable for students",
-        "Prioritizes actionable learning outcomes",
-        "Maintains academic tone while being accessible",
-      ],
-    },
-    format: {
-      structure: "markdown",
-      requirements: [
-        "Use clear, concise language suitable for students",
-        "Use bullet points and headers for readability",
-        "Maintain academic tone while being accessible",
-      ],
-      length: {
-        min: 300,
-        max: 400,
-        target: 350,
-        unit: "words",
-      },
-      specialFormatting: {
-        includeHeaders: true,
-        useEmphasis: true,
-      },
-    },
-    context: {
-      subject: {
-        area: "Academic Curriculum Analysis",
-        level: "Higher Education",
-      },
-      student: {
-        priorKnowledge: "Basic understanding of educational concepts",
-        learningStyle: "Visual and structured learning",
-        goals: [
-          "Understand course structure",
-          "Identify learning outcomes",
-          "Prepare for coursework",
-        ],
-      },
-    },
-    references: {
-      includeReferences: false,
-      citationStyle: "simple",
-    },
-  };
-
-  // Validate the format
-  const validation = validateStandardizedFormat(aiFormat);
-  if (!validation.isValid) {
-    console.warn("Standardized format validation failed:", validation.errors);
   }
 
   try {
-    // Create standardized prompts
-    const standardizedPrompt = createStandardizedPrompt({
-      format: aiFormat,
-      userMessage: `Please analyze the following syllabus text and create a comprehensive summary:\n\n**SYLLABUS TEXT:**\n${input.syllabusText}\n\nCreate a well-structured summary that includes:\n\n## Course Overview\n- Subject area and level\n- Duration and credit information (if available)\n\n## Key Learning Objectives\n- List 4-6 primary learning goals\n- Focus on what students will be able to DO after completion\n\n## Core Knowledge Areas\n- Main topics and concepts covered\n- Theoretical foundations\n- Practical applications\n\n## Skills Development\n- Technical skills gained\n- Analytical and critical thinking abilities\n- Professional competencies\n\n## Assessment Methods\n- Types of evaluations mentioned\n- Projects and practical work\n\nGenerate the summary now, ensuring it captures the essence of what students will learn and achieve in this course.`,
-    });
-
     const chatCompletion = await ai.chat.completions.create({
       messages: [
         {
           role: "system",
-          content: standardizedPrompt.systemPrompt,
+          content: [
+            "You summarize university course syllabi for the students taking them.",
+            "Write at most 120 words total:",
+            "1. Two or three plain sentences: what the course is about and why it matters in practice.",
+            "2. Then exactly three short bullets starting with a verb: what the student will be able to do afterward.",
+            "Rules: no headings, no bold section labels, no academic boilerplate.",
+            "Never write 'not specified' or mention missing information; if something is absent from the syllabus, leave it out entirely.",
+            "Ground every claim in the syllabus text you are given.",
+          ].join("\n"),
         },
         {
           role: "user",
-          content: standardizedPrompt.userPrompt,
+          content: input.syllabusText,
         },
       ],
       model: "llama-3.1-8b-instant",
-      temperature: 0.3, // Reduced for more consistent, factual output
-      max_completion_tokens: 1024,
-      top_p: 0.85,
+      temperature: 0.3,
+      max_completion_tokens: 300,
     });
 
-    const summary = chatCompletion.choices?.[0]?.message?.content;
-
-    // Validate AI response
-    if (!summary || summary.trim().length < 50) {
+    const summary = chatCompletion.choices?.[0]?.message?.content?.trim();
+    if (!summary || summary.length < 40) {
       throw new Error("AI response too short or empty");
     }
-
-    // Additional validation for educational content in summary
-    const educationalCheck =
-      /\b(learn|study|understand|concept|skill|knowledge|academic|course|student)\b/i;
-    const nonEducationalCheck =
-      /\b(messi|ronaldo|celebrity|entertainment|sports|movie|gaming)\b/i;
-
-    if (nonEducationalCheck.test(summary) || !educationalCheck.test(summary)) {
-      return {
-        summary:
-          "I can only summarize educational and academic content. The provided material doesn't appear to contain standard syllabus information such as learning objectives, course topics, or educational outcomes. Please provide authentic course syllabus content for summarization.",
-      };
-    }
-
-    return { summary: summary.trim() };
+    return { summary };
   } catch (error) {
     console.error("Error in syllabus summarization:", error);
-
-    // Provide detailed error handling based on error type
-    if (error instanceof Error) {
-      if (
-        error.message.includes("rate limit") ||
-        error.message.includes("429")
-      ) {
-        return {
-          summary:
-            "The AI service is currently experiencing high demand. Please wait a moment and try generating the summary again. The syllabus content is ready for analysis once the service is available.",
-        };
-      }
-
-      if (
-        error.message.includes("timeout") ||
-        error.message.includes("network")
-      ) {
-        return {
-          summary:
-            "There was a network issue while generating the syllabus summary. Please check your connection and try again. The content appears to be valid educational material.",
-        };
-      }
-
-      if (
-        error.message.includes("content") ||
-        error.message.includes("filter")
-      ) {
-        return {
-          summary:
-            "The syllabus content couldn't be processed due to content restrictions. Please ensure the material contains standard academic content like learning objectives, course topics, and educational outcomes.",
-        };
-      }
-    }
-
-    // Generic fallback with basic syllabus structure
     return {
-      summary: `## Course Summary
-
-I encountered an issue generating a detailed summary for this syllabus. However, based on the provided content, this appears to be educational course material.
-
-## Key Points
-- This course covers important academic concepts and learning objectives
-- Students will develop both theoretical knowledge and practical skills
-- The curriculum is designed to meet educational standards and learning outcomes
-
-## Next Steps
-- Try regenerating the summary in a moment
-- Ensure the syllabus content includes clear learning objectives
-- Verify that all course topics and assessment methods are included
-
-Please try generating the summary again, or contact support if the issue persists. The syllabus content appears to be properly formatted educational material.`,
+      summary:
+        "The overview could not be generated right now (the AI service may be busy). The full module list below is the source of truth; try again in a moment.",
     };
   }
-};
+}

--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/CourseModules.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/CourseModules.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Sparkles, BrainCircuit } from "lucide-react";
 import { motion } from "framer-motion";
+import toast from "react-hot-toast";
 import { Spinner } from "@/components/ui/spinner";
 import { Module, CourseModulesProps } from "@/lib/types";
 import {
@@ -61,17 +62,13 @@ export function CourseModules({ modules }: CourseModulesProps) {
     setStatuses((prev) => ({ ...prev, [title]: status }));
   };
 
-  const handleChatRedirect = async (module: Module, index: number) => {
+  const handleChatRedirect = (module: Module, index: number) => {
     if (!module.content.trim()) {
-      // Consider using a toast notification for a better UX
-      alert("No content available for this module.");
+      toast.error("No content available for this module yet.");
       return;
     }
 
     setLoadingModuleIndex(index);
-
-    // Add aesthetic delay for smooth UX
-    await new Promise((resolve) => setTimeout(resolve, 600));
 
     const title = module.title || "Selected Module";
     const syllabusUrl = window.location.pathname;
@@ -122,55 +119,49 @@ export function CourseModules({ modules }: CourseModulesProps) {
                         "No detailed content available."}
                     </p>
                   </div>
-                  <Button
-                    onClick={() => handleChatRedirect(module, index)}
-                    disabled={loadingModuleIndex === index}
-                    className="flex items-center gap-2 group disabled:opacity-70 disabled:cursor-not-allowed"
-                    style={{
-                      background:
-                        loadingModuleIndex === index
-                          ? "linear-gradient(90deg, rgba(120,119,198,0.3) 0%, rgba(255,255,255,0.3) 50%, rgba(120,119,198,0.3) 100%)"
-                          : undefined,
-                      backgroundSize:
-                        loadingModuleIndex === index
-                          ? "1000px 100%"
-                          : undefined,
-                      animation:
-                        loadingModuleIndex === index
-                          ? "shimmer 2s infinite linear"
-                          : undefined,
-                    }}
-                  >
-                    {loadingModuleIndex === index ? (
-                      <Spinner className="h-4 w-4" />
-                    ) : (
-                      <Sparkles className="h-4 w-4 text-amber-300 transition-transform group-hover:scale-125" />
-                    )}
-                    Chat with AI about this Module
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={() =>
-                      router.push(
-                        `/brainstorm?title=${encodeURIComponent(
-                          module.title || "Selected Module"
-                        )}&content=${encodeURIComponent(module.content)}`
-                      )
-                    }
-                    className="flex items-center gap-2 mt-2 border-primary/40 text-primary hover:bg-primary/10"
-                  >
-                    <BrainCircuit className="h-4 w-4" />
-                    Brainstorm before class
-                  </Button>
+                  {/* Brainstorm is the product's primary verb; chat is the
+                      fallback. The hierarchy must say so. */}
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      onClick={() =>
+                        router.push(
+                          `/brainstorm?title=${encodeURIComponent(
+                            module.title || "Selected Module"
+                          )}&content=${encodeURIComponent(module.content)}`
+                        )
+                      }
+                      className="flex items-center gap-2"
+                    >
+                      <BrainCircuit className="h-4 w-4" />
+                      Brainstorm before class
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => handleChatRedirect(module, index)}
+                      disabled={loadingModuleIndex === index}
+                      className="flex items-center gap-2 group border-primary/40 text-primary hover:bg-primary/10 disabled:opacity-70 disabled:cursor-not-allowed"
+                    >
+                      {loadingModuleIndex === index ? (
+                        <Spinner className="h-4 w-4" />
+                      ) : (
+                        <Sparkles className="h-4 w-4 transition-transform group-hover:scale-125" />
+                      )}
+                      Ask the AI to explain
+                    </Button>
+                  </div>
                   {module.title && (
                     <div className="mt-4 flex flex-wrap items-center gap-2">
-                      <span className="text-xs text-muted-foreground">
+                      <span
+                        className="text-xs text-muted-foreground"
+                        title="Your private read on this module. Saved on this device only; drives your Journey and exam runway."
+                      >
                         Where do you stand on this module?
                       </span>
                       {STATUS_OPTIONS.map((opt) => (
                         <button
                           key={opt.id}
                           type="button"
+                          title="Saved on this device only. Feeds your Journey page and exam runway."
                           onClick={() => updateStatus(module.title!, opt.id)}
                           className={`text-[11px] px-2.5 py-1 rounded-full border transition-colors ${
                             statuses[module.title!] === opt.id

--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/SyllabusSummary.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/SyllabusSummary.tsx
@@ -1,53 +1,107 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { BookText } from "lucide-react";
+import { BookText, Sparkles } from "lucide-react";
 import { summarizeSyllabus } from "@/ai/flows/summarize-syllabus";
 import { motion, AnimatePresence } from "framer-motion";
 import { Streamdown } from "streamdown";
+import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { SyllabusSummaryProps } from "@/lib/types";
+
+/**
+ * On-demand course overview.
+ *
+ * Deliberately NOT auto-generated on mount: that made an AI call on every
+ * page view (cost, latency) and pushed the real syllabus content below a
+ * wall of generated text. The student asks for it; the result is cached on
+ * the device so asking is a one-time cost per subject.
+ */
+
+const CACHE_PREFIX = "syllabus-summary:v2:";
+
+// Stable tiny hash so the cache key survives whitespace-level data edits
+function contentKey(text: string): string {
+  let h = 0;
+  for (let i = 0; i < text.length; i++) {
+    h = (Math.imul(31, h) + text.charCodeAt(i)) | 0;
+  }
+  return CACHE_PREFIX + (h >>> 0).toString(36);
+}
 
 export function SyllabusSummary({ fullSyllabus }: SyllabusSummaryProps) {
   const [summary, setSummary] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Auto-generate summary on mount
+  // Show a cached summary instantly if this subject was summarized before
   useEffect(() => {
-    const generateSummary = async () => {
-      if (!fullSyllabus.trim()) {
-        setSummary("No syllabus content available to summarize.");
-        return;
-      }
-
-      setLoading(true);
-      setError(null);
-      try {
-        const result = await summarizeSyllabus({ syllabusText: fullSyllabus });
-        setSummary(result.summary);
-      } catch (e: any) {
-        console.error("Error summarizing syllabus:", e);
-        setError("Failed to generate summary.");
-        setSummary(null);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    generateSummary();
+    if (!fullSyllabus.trim()) return;
+    try {
+      const cached = localStorage.getItem(contentKey(fullSyllabus));
+      if (cached) setSummary(cached);
+    } catch {
+      // no storage, no cache: the button still works
+    }
   }, [fullSyllabus]);
 
+  const generate = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await summarizeSyllabus({ syllabusText: fullSyllabus });
+      setSummary(result.summary);
+      try {
+        localStorage.setItem(contentKey(fullSyllabus), result.summary);
+      } catch {
+        // cache write is best-effort
+      }
+    } catch (e) {
+      console.error("Error summarizing syllabus:", e);
+      setError("Could not generate the overview. Try again in a moment.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!fullSyllabus.trim()) return null;
+
   return (
-    <div className="space-y-4 bg-white dark:bg-black/50 backdrop-blur-sm p-6 rounded-2xl shadow-md border h-[500px] overflow-auto">
-      <div className="flex items-center gap-3">
-        <div className="p-2 bg-primary/10 rounded-lg">
-          <BookText className="h-6 w-6 text-primary" />
+    <div className="space-y-4 bg-white dark:bg-black/50 backdrop-blur-sm p-6 rounded-2xl shadow-md border max-h-[500px] overflow-auto">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-primary/10 rounded-lg">
+            <BookText className="h-6 w-6 text-primary" />
+          </div>
+          <h3 className="text-xl font-bold">This course, in short</h3>
         </div>
-        <h3 className="text-xl font-bold">Syllabus Summary</h3>
+        {summary && !loading && (
+          <Button size="sm" variant="ghost" onClick={generate}>
+            Regenerate
+          </Button>
+        )}
       </div>
 
       <AnimatePresence mode="wait">
+        {!summary && !loading && !error && (
+          <motion.div
+            key="idle"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            className="space-y-3"
+          >
+            <p className="text-sm text-muted-foreground">
+              A plain-language overview of what this course is about and what
+              you will be able to do after it. Generated once, then saved on
+              your device.
+            </p>
+            <Button onClick={generate} variant="outline" className="gap-2">
+              <Sparkles className="h-4 w-4" />
+              Summarize this course
+            </Button>
+          </motion.div>
+        )}
+
         {loading && (
           <motion.div
             key="loader"
@@ -56,19 +110,22 @@ export function SyllabusSummary({ fullSyllabus }: SyllabusSummaryProps) {
             className="flex items-center justify-center space-x-2 text-muted-foreground py-4"
           >
             <Spinner className="h-5 w-5" />
-            <span>Generating summary...</span>
+            <span>Reading the syllabus...</span>
           </motion.div>
         )}
 
-        {error && (
-          <motion.p
+        {error && !loading && (
+          <motion.div
             key="error"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            className="text-destructive text-center py-4"
+            className="text-center py-4 space-y-2"
           >
-            {error}
-          </motion.p>
+            <p className="text-destructive text-sm">{error}</p>
+            <Button size="sm" variant="outline" onClick={generate}>
+              Try again
+            </Button>
+          </motion.div>
         )}
 
         {summary && !loading && !error && (
@@ -76,6 +133,7 @@ export function SyllabusSummary({ fullSyllabus }: SyllabusSummaryProps) {
             key="summary"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
+            className="text-sm leading-relaxed"
           >
             <Streamdown>{summary}</Streamdown>
           </motion.div>

--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/page.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { notFound } from "next/navigation";
+import { titleCase } from "@/lib/utils";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { SyllabusSummary } from "./_components/SyllabusSummary";
@@ -12,7 +13,8 @@ import { AnimatedDiv } from "@/components/AnimatedDiv";
 
 import { useUniversityData } from "@/contexts";
 import { Spinner } from "@/components/ui/spinner";
-import { use } from "react";
+import { use, useEffect } from "react";
+import { Pencil } from "lucide-react";
 import { SubjectPageProps, DirectoryStructure } from "@/lib/types";
 import { Header } from "@/components/Header";
 
@@ -72,14 +74,7 @@ function formatSemesterName(semesterId: string): string {
   return `Semester ${semesterId.replace("s", "").replace(/^0+/, "")}`;
 }
 function capitalizeWords(str: string | undefined): string {
-  if (!str) return "";
-  return str
-    .replace(/-/g, " ") // replace all "-" with spaces
-    .split(" ")
-    .map((word) =>
-      word.length > 0 ? word.charAt(0).toUpperCase() + word.slice(1) : ""
-    )
-    .join(" ");
+  return titleCase(str);
 }
 
 export default function SubjectPage({ params }: SubjectPageProps) {
@@ -90,6 +85,19 @@ export default function SubjectPage({ params }: SubjectPageProps) {
     isFetching,
     data: directoryStructure,
   } = useUniversityData(resolvedParams.university);
+
+  // Browser-tab / history title. Students search and share by subject code;
+  // full crawler metadata needs the server-component refactor (M2).
+  const pageData = directoryStructure
+    ? findDataPath(directoryStructure, resolvedParams)
+    : null;
+  useEffect(() => {
+    if (pageData) {
+      document.title = `${capitalizeWords(pageData.subject.name)} (${
+        pageData.subject.code ?? pageData.subject.id
+      }) | Beyond Syllabus`;
+    }
+  }, [pageData]);
 
   if (isFetching) {
     return (
@@ -110,13 +118,15 @@ export default function SubjectPage({ params }: SubjectPageProps) {
     );
   }
 
-  const dataPath = findDataPath(directoryStructure, resolvedParams);
+  const dataPath = pageData;
 
   if (!dataPath) {
     notFound();
   }
 
   const { university, program, scheme, semester, subject } = dataPath;
+
+  const wikiSourceUrl = `https://github.com/The-Purple-Movement/WikiSyllabus/tree/main/universities/${university.id}/${program.id}/${scheme.id}/${semester.id}`;
 
   const breadcrumbItems = [
     { label: "Home", href: "/" },
@@ -133,7 +143,7 @@ export default function SubjectPage({ params }: SubjectPageProps) {
       label: semester.name,
       href: `/${university.id}/${program.id}/${scheme.id}/${semester.id}`,
     },
-    { label: subject.name },
+    { label: capitalizeWords(subject.name) },
   ];
 
   return (
@@ -151,6 +161,16 @@ export default function SubjectPage({ params }: SubjectPageProps) {
               <p className="text-muted-foreground mt-2 text-lg">
                 {subject.code}
               </p>
+              <a
+                href={wikiSourceUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1.5 mt-3 text-xs text-muted-foreground hover:text-primary transition-colors"
+              >
+                <Pencil className="h-3 w-3" />
+                Spotted an error? This syllabus is a markdown file on
+                WikiSyllabus. Fix it there and it updates here.
+              </a>
             </div>
 
             <div className="grid gap-12 lg:grid-cols-[1fr_350px] ">

--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/page.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { notFound } from "next/navigation";
+import { titleCase } from "@/lib/utils";
 import { useRouter } from "next/navigation";
 import { useState, use } from "react";
 
@@ -71,11 +72,7 @@ function findSemesterData(
 }
 
 function capitalizeWords(str: string | undefined): string {
-  if (!str) return "";
-  return str
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
+  return titleCase(str);
 }
 
 function formatSemesterName(semesterId: string): string {
@@ -139,14 +136,7 @@ export default function SubjectsPage({ params }: SubjectsPageProps) {
   }
 
   function capitalizeWords(str: string | undefined): string {
-    if (!str) return "";
-    return str
-      .replace(/-/g, " ")
-      .split(" ")
-      .map((word) =>
-        word.length > 0 ? word.charAt(0).toUpperCase() + word.slice(1) : ""
-      )
-      .join(" ");
+    return titleCase(str);
   }
 
   const { university, program, scheme, semester } = dataPath;

--- a/apps/web/src/app/brainstorm/page.tsx
+++ b/apps/web/src/app/brainstorm/page.tsx
@@ -77,6 +77,12 @@ export default function BrainstormPage() {
     setModuleContent(params.get("content") || "");
   }, []);
 
+  useEffect(() => {
+    document.title = moduleTitle
+      ? `Brainstorm: ${moduleTitle} | Beyond Syllabus`
+      : "Guided Brainstorm | Beyond Syllabus";
+  }, [moduleTitle]);
+
   // Restore a previously built sheet for this module
   useEffect(() => {
     if (!storageKey) return;
@@ -327,6 +333,7 @@ export default function BrainstormPage() {
             onSend={handleSend}
             disabled={loading}
             onModelChange={setModel}
+            showModelSelector={false}
           />
         </div>
 

--- a/apps/web/src/app/chat/_components/ChatInput.tsx
+++ b/apps/web/src/app/chat/_components/ChatInput.tsx
@@ -13,6 +13,7 @@ export function ChatInput({
   className,
   disabled = false,
   onModelChange,
+  showModelSelector = true,
 }: ChatInputProps) {
   const [message, setMessage] = useState("");
 
@@ -79,6 +80,7 @@ export function ChatInput({
           variant={"outline"}
           onClick={handleSubmit}
           disabled={disabled || !message.trim()}
+          aria-label="Send message"
           className={cn(
             "flex items-center justify-center w-9 h-9 mt-1 rounded-full border border-border bg-purple-500 text-white",
             "transition-colors",
@@ -89,9 +91,11 @@ export function ChatInput({
         </Button>
       </div>
 
-      <div className="flex items-center gap-2">
-        <ModelSelector value={selectedModel} onChange={setSelectedModel} />
-      </div>
+      {showModelSelector && (
+        <div className="flex items-center gap-2">
+          <ModelSelector value={selectedModel} onChange={setSelectedModel} />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/chat/_components/Model-Selector.tsx
+++ b/apps/web/src/app/chat/_components/Model-Selector.tsx
@@ -11,10 +11,12 @@ import { ChevronDown, ChevronUp, Cpu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Model, ModelSelectorProps } from "@/lib/types";
 
+// Honest labels only: these are open models served by Groq, and saying
+// otherwise (the old "GPT 5" label) breaks trust the moment anyone checks.
 const models: Model[] = [
-  { id: "openai/gpt-oss-120b", name: "GPT 5" },
-  { id: "openai/gpt-oss-20b", name: "GPT 4.1" },
-  { id: "llama-3.1-8b-instant", name: "LLama 3" },
+  { id: "openai/gpt-oss-120b", name: "Thorough · GPT-OSS 120B" },
+  { id: "openai/gpt-oss-20b", name: "Balanced · GPT-OSS 20B" },
+  { id: "llama-3.1-8b-instant", name: "Fastest · Llama 3.1 8B" },
 ];
 
 
@@ -43,14 +45,14 @@ export default function ModelSelector({ onChange }: ModelSelectorProps) {
 
   if (!isClient) return null;
 
-  const selectedName = models.find((m) => m.id === selected)?.name || "GPT 5";
+  const selectedName = models.find((m) => m.id === selected)?.name || models[0].name;
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
-          className="w-36 justify-between bg-transparent hover:text-white ring-1 ring-[#4d4c4c]"
+          className="w-56 justify-between bg-transparent hover:text-white ring-1 ring-[#4d4c4c] text-xs"
         >
           <Cpu className="w-4 h-4 text-[#B56DFC]" />
           <span>{selectedName}</span>
@@ -61,7 +63,7 @@ export default function ModelSelector({ onChange }: ModelSelectorProps) {
           )}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-36 bg-[#DEDEDF] dark:bg-[#181818] gap-2 px-3 py-4">
+      <DropdownMenuContent className="w-56 bg-[#DEDEDF] dark:bg-[#181818] gap-2 px-3 py-4">
         {models.map((model) => (
           <DropdownMenuItem
             key={model.id}

--- a/apps/web/src/app/journey/page.tsx
+++ b/apps/web/src/app/journey/page.tsx
@@ -88,6 +88,7 @@ export default function JourneyPage() {
 
   useEffect(() => {
     refresh();
+    document.title = "My Journey | Beyond Syllabus";
   }, []);
 
   const handleExport = () => {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -23,9 +23,12 @@ const montserrat = Montserrat({
 
 
 export const metadata: Metadata = {
-  title: "BeyondSyllabus",
+  title: {
+    default: "Beyond Syllabus",
+    template: "%s | Beyond Syllabus",
+  },
   description:
-    "Your modern, AI-powered guide to the university curriculum. Explore subjects, understand modules, and unlock your potential.",
+    "Walk into class with questions worth asking. Brainstorm before class, build your question sheet, and track where you stand. Free, open source, built on WikiSyllabus.",
   authors: [{ name: "µLearn" }],
   openGraph: {
     title: "BeyondSyllabus",

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -45,44 +45,57 @@ export default function Home() {
               </AuroraText>
             </h1>
             <p className="max-w-2xl text-lg md:text-xl text-black dark:text-white mt-4">
-              Your modern, AI-powered guide to the university curriculum.
-              Explore subjects, understand modules, and unlock your potential.
+              Walk into class with questions worth asking. Your syllabus,
+              turned into a thinking tool: brainstorm before class, build your
+              question sheet, and track where you actually stand.
             </p>
 
             <div className="flex flex-col md:flex-row justify-center gap-4 mt-8 ">
-              <Button
-                asChild
-                size="lg"
-                variant="secondary"
-                className="w-full md:w-auto flex items-center justify-center gap-2 h-[44px]"
-              >
-                <Link href="/chat">
-                  <Sparkles className="h-5 w-5 text-amber-400" />
-                  AI Chat
-                </Link>
-              </Button>
-
               <Button
                 size="lg"
                 className="group shadow-lg w-full md:w-auto h-[44px] bg-[#8800ff]"
                 asChild
                 disabled={loadingRoute === "/select"}
               >
-                <Link href="/select" onClick={() => navigateWithDelay("/select", 800)}>
+                <Link href="/select" onClick={() => navigateWithDelay("/select", 300)}>
                   {loadingRoute ? (
                     <>
                       <Spinner className="h-5 w-5 mr-2" />
-                      Loading Syllabus...
+                      Loading...
                     </>
                   ) : (
                     <>
-                      Explore Your Syllabus
+                      Find your syllabus
                       <ChevronRight className="h-5 w-5 ml-2 group-hover:translate-x-1 transition-transform" />
                     </>
                   )}
                 </Link>
               </Button>
+
+              <Button
+                asChild
+                size="lg"
+                variant="secondary"
+                className="w-full md:w-auto flex items-center justify-center gap-2 h-[44px]"
+              >
+                <Link href="/journey">
+                  <Sparkles className="h-5 w-5 text-amber-400" />
+                  My Journey
+                </Link>
+              </Button>
             </div>
+
+            <p className="text-sm text-muted-foreground mt-6">
+              Free and open source. No account needed. Built on{" "}
+              <Link
+                href="https://github.com/The-Purple-Movement/WikiSyllabus"
+                target="_blank"
+                className="underline hover:text-primary"
+              >
+                WikiSyllabus
+              </Link>
+              , the open syllabus commons.
+            </p>
           </div>
         </section>
 
@@ -93,12 +106,12 @@ export default function Home() {
                 Key Features
               </div>
               <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold tracking-tight text-black dark:text-white">
-                Learn Smarter, Not Harder
+                The class works better when you arrive curious
               </h2>
               <p className="max-w-[900px] mx-auto text-gray-700 dark:text-gray-300 md:text-xl leading-relaxed">
-                Our platform is designed to streamline your learning process,
-                from understanding complex topics to finding the best study
-                materials.
+                Beyond Syllabus is built for the flipped classroom: the AI
+                helps you sharpen questions before class instead of handing
+                you answers after it.
               </p>
             </div>
           </div>
@@ -106,18 +119,18 @@ export default function Home() {
           <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 max-w-6xl mx-auto px-4 md:px-6">
             <FeatureCard
               icon={<BookOpenCheck className="h-8 w-8 text-purple-700" />}
-              title="Structured Syllabus"
-              description="Access your complete university syllabus, broken down by program, semester, and subject."
+              title="Brainstorm before class"
+              description="A three-stage guided session on any module: prime what you know, explore the edges, and leave with sharp questions."
             />
             <FeatureCard
               icon={<GraduationCap className="h-8 w-8 text-purple-700" />}
-              title="AI-Powered Insights"
-              description="Get concise summaries of your syllabus modules and chat with an AI to grasp key concepts quickly."
+              title="Your Question Sheet"
+              description="Collect the questions worth asking, export them as markdown, or send them to your teacher's classroom anonymously."
             />
             <FeatureCard
               icon={<BarChart3 className="h-8 w-8 text-purple-700" />}
-              title="Learning Tools"
-              description="Generate learning tasks and discover real-world applications for each module."
+              title="Journey and exam runway"
+              description="Track where you stand module by module and get a revision plan built around your weak spots. All on your device, no account."
             />
           </div>
         </section>

--- a/apps/web/src/app/select/_components/SelectionForm.tsx
+++ b/apps/web/src/app/select/_components/SelectionForm.tsx
@@ -23,12 +23,13 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Info, BookOpen } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, titleCase } from "@/lib/utils";
 import { useData } from "@/contexts/dataContext";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import { Spinner } from "@/components/ui/spinner";
+import { getLastSelection, saveLastSelection } from "@/lib/journey";
 
-const cap = (s?: string) => (s ? s.replace(/-/g, " ").toUpperCase() : "");
+const cap = (s?: string) => titleCase(s);
 const semName = (id: string) => `Semester ${id.replace("s", "").replace(/^0+/, "")}`;
 const semNum = (id: string) => Number(id.replace(/\D/g, "")) || 999;
 
@@ -58,6 +59,7 @@ export function SelectionForm() {
   const [sem, setSem] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState("");
+  const [lastSelection] = useState(() => getLastSelection());
 
   const steps = ["University", "Program", "Scheme", "Semester"];
 
@@ -73,7 +75,7 @@ export function SelectionForm() {
   ) => {
     setIsLoading(true);
     setLoadingMessage(message);
-    await Promise.all([task?.(), new Promise((r) => setTimeout(r, 600))]);
+    await Promise.all([task?.(), new Promise((r) => setTimeout(r, 200))]);
     fn();
     setIsLoading(false);
     setStep(nextStep);
@@ -87,12 +89,14 @@ export function SelectionForm() {
     setStep(level);
   };
 
-  const submit = async () => {
-    if (!u || !p || !sch || !sem) return;
+  // Takes the semester id directly: reading `sem` state here would race the
+  // setState from the same click (the old first-tap-does-nothing bug).
+  const submit = (semId: string) => {
+    if (!u || !p || !sch) return;
+    saveLastSelection({ university: u, program: p, scheme: sch, semester: semId });
     setIsLoading(true);
-    setLoadingMessage("Loading syllabus modules...");
-    await new Promise((r) => setTimeout(r, 800));
-    router.push(`/${u}/${p}/${sch}/${sem}`);
+    setLoadingMessage("Loading your subjects...");
+    router.push(`/${u}/${p}/${sch}/${semId}`);
   };
 
   if (isFetching) return null;
@@ -167,6 +171,22 @@ export function SelectionForm() {
               {step === 1 && (
                 <MotionDiv key="step1" variants={stepVariants} initial="hidden" animate="visible" exit="exit" className="flex justify-center">
                   <div className="space-y-4 flex flex-col items-center">
+                    {lastSelection && universities.includes(lastSelection.university) && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          router.push(
+                            `/${lastSelection.university}/${lastSelection.program}/${lastSelection.scheme}/${lastSelection.semester}`
+                          )
+                        }
+                        className="w-[280px] text-left p-3 rounded-xl border border-primary/40 bg-primary/5 hover:bg-primary/10 transition-colors"
+                      >
+                        <p className="text-xs text-muted-foreground">Continue where you left off</p>
+                        <p className="text-sm font-semibold">
+                          {cap(lastSelection.program)} · {semName(lastSelection.semester)}
+                        </p>
+                      </button>
+                    )}
                     <Label className="text-lg font-bold">1. Select Your University</Label>
                     <Select
                       onValueChange={(v) =>
@@ -196,7 +216,22 @@ export function SelectionForm() {
                 <MotionDiv key="step2" variants={stepVariants} initial="hidden" animate="visible" exit="exit" className="flex justify-center">
                   <div className="space-y-4 flex flex-col items-center">
                     <Label className="text-lg font-bold">2. Choose Your Program</Label>
-                    <Select value={p ?? ""} onValueChange={(v) => loadStep("Loading schemes...", 3, () => setP(v))}>
+                    <Select
+                      value={p ?? ""}
+                      onValueChange={(v) => {
+                        // One scheme? Choosing from a single option is not a
+                        // decision: skip straight to semesters.
+                        const schemes = u ? Object.keys(directory[u]?.[v] ?? {}) : [];
+                        if (schemes.length === 1) {
+                          loadStep("Loading semesters...", 4, () => {
+                            setP(v);
+                            setSch(schemes[0]);
+                          });
+                        } else {
+                          loadStep("Loading schemes...", 3, () => setP(v));
+                        }
+                      }}
+                    >
                       <SelectTrigger className="w-[280px] py-3 px-3 rounded-xl border border-purple-300 bg-white dark:bg-gray-900 shadow-sm">
                         <SelectValue placeholder="Select Program" />
                       </SelectTrigger>
@@ -265,7 +300,7 @@ export function SelectionForm() {
                             )}
                             onClick={() => {
                               setSem(id);
-                              submit();
+                              submit(id);
                             }}
                           >
                             <RadioGroupItem value={id} className="sr-only" />
@@ -274,7 +309,28 @@ export function SelectionForm() {
                           </div>
                         ))}
                     </RadioGroup>
-
+                    {(() => {
+                      const nums = Object.keys(schemeData)
+                        .map(semNum)
+                        .sort((a, b) => a - b);
+                      const hasGaps =
+                        nums.length > 0 &&
+                        (nums[0] > 1 || nums[nums.length - 1] - nums[0] + 1 !== nums.length);
+                      return hasGaps ? (
+                        <p className="text-xs text-muted-foreground text-center pt-2">
+                          Not seeing your semester? It has not been contributed yet.{" "}
+                          <a
+                            href="https://github.com/The-Purple-Movement/WikiSyllabus"
+                            target="_blank"
+                            rel="noreferrer"
+                            className="underline text-primary"
+                          >
+                            Add it on WikiSyllabus
+                          </a>{" "}
+                          and it appears here for everyone.
+                        </p>
+                      ) : null;
+                    })()}
                 </MotionDiv>
               )}
             </>

--- a/apps/web/src/app/select/page.tsx
+++ b/apps/web/src/app/select/page.tsx
@@ -1,6 +1,13 @@
+import type { Metadata } from "next";
 import { Header } from "@/components/Header";
 import { SelectionForm } from "./_components/SelectionForm";
 import { AnimatedDiv } from "@/components/AnimatedDiv";
+
+export const metadata: Metadata = {
+  title: "Find your syllabus",
+  description:
+    "Pick your university, program, and semester to open your syllabus on Beyond Syllabus.",
+};
 
 export default async function SelectPage() {
   return (

--- a/apps/web/src/app/teach/page.tsx
+++ b/apps/web/src/app/teach/page.tsx
@@ -60,6 +60,7 @@ export default function TeachPage() {
   const [loadingView, setLoadingView] = useState(false);
 
   useEffect(() => {
+    document.title = "For Teachers | Beyond Syllabus";
     try {
       setSaved(JSON.parse(localStorage.getItem(SAVED_KEY) || "[]"));
     } catch {

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -50,12 +50,13 @@ export function Footer() {
               <h3 className="text-sm font-semibold mb-3">Navigation</h3>
               <nav className="flex flex-col gap-2">
                 <Link href="/">Home</Link>
-                <Link href="/select">Select Course</Link>
-                <Link href="/chat">AI Chat</Link>
+                <Link href="/select">Find a Syllabus</Link>
+                <Link href="/journey">My Journey</Link>
+                <Link href="/teach">For Teachers</Link>
               </nav>
             </div>
             <div>
-              <h3 className="text-sm font-semibold mb-3">Resources</h3>
+              <h3 className="text-sm font-semibold mb-3">Contribute</h3>
               <nav className="flex flex-col gap-2">
                 <Link href="https://github.com/The-Purple-Movement/Beyond-Syllabus/blob/main/CONTRIBUTION.md">Contribution Guide</Link>
                 <Link href="https://github.com/The-Purple-Movement/Beyond-Syllabus/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</Link>
@@ -63,10 +64,11 @@ export function Footer() {
               </nav>
             </div>
             <div>
-              <h3 className="text-sm font-semibold mb-3">Legal</h3>
+              <h3 className="text-sm font-semibold mb-3">Ecosystem</h3>
               <nav className="flex flex-col gap-2">
-                <Link href="https://github.com/The-Purple-Movement/Beyond-Syllabus">Terms of Service</Link>
-                <Link href="https://github.com/The-Purple-Movement/Beyond-Syllabus">Privacy Policy</Link>
+                <Link href="https://github.com/The-Purple-Movement/WikiSyllabus" target="_blank">WikiSyllabus (the data)</Link>
+                <Link href="https://mulearn.org" target="_blank">μLearn</Link>
+                <Link href="https://github.com/The-Purple-Movement" target="_blank">The Purple Movement</Link>
               </nav>
             </div>
           </div>
@@ -74,8 +76,9 @@ export function Footer() {
 
         <div className="mt-8 border-t pt-6 text-center text-xs text-muted-foreground">
           <p>
-            {new Date().getFullYear()} BeyondSyllabus. All rights reserved. An
-            open-source project.
+            {new Date().getFullYear()} Beyond Syllabus. Free and open source
+            (MIT). Syllabus data from WikiSyllabus, kept alive by its
+            contributors.
           </p>
         </div>
       </div>

--- a/apps/web/src/lib/journey.ts
+++ b/apps/web/src/lib/journey.ts
@@ -283,3 +283,38 @@ export function importAllData(raw: string): { imported: number } {
   }
   return { imported };
 }
+
+/**
+ * Last course selection: remembered so returning students skip the wizard.
+ * Same local-first rules as the journey itself.
+ */
+export interface LastSelection {
+  university: string;
+  program: string;
+  scheme: string;
+  semester: string;
+}
+
+const SELECTION_KEY = "journey:last-selection";
+
+export function saveLastSelection(sel: LastSelection): void {
+  if (!isBrowser()) return;
+  try {
+    localStorage.setItem(SELECTION_KEY, JSON.stringify(sel));
+  } catch {
+    // storage full or blocked: losing the shortcut is acceptable
+  }
+}
+
+export function getLastSelection(): LastSelection | null {
+  if (!isBrowser()) return null;
+  try {
+    const raw = localStorage.getItem(SELECTION_KEY);
+    if (!raw) return null;
+    const sel = JSON.parse(raw) as LastSelection;
+    if (sel.university && sel.program && sel.scheme && sel.semester) return sel;
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -324,4 +324,6 @@ export interface ChatInputProps {
   className?: string;
   disabled?: boolean;
   onModelChange?: (modelId: string) => void;
+  /** Hide the model dropdown (e.g. guided brainstorm: pedagogy, not knobs) */
+  showModelSelector?: boolean;
 }

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -4,3 +4,31 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Words that stay lowercase mid-title; acronyms that stay uppercase anywhere.
+const MINOR_WORDS = new Set([
+  "a", "an", "and", "as", "at", "by", "for", "in", "of", "on", "or", "the", "to", "with",
+]);
+const ACRONYMS = new Set([
+  "ai", "aiml", "ml", "iot", "it", "cse", "ece", "eee", "vlsi", "ktu", "apj",
+  "ii", "iii", "iv", "vi", "vii", "viii",
+]);
+
+/**
+ * Turn a data-derived slug or ALL CAPS name into a human title.
+ * "artificial-intelligence-and-data-science" -> "Artificial Intelligence and Data Science"
+ */
+export function titleCase(input?: string): string {
+  if (!input) return "";
+  return input
+    .replace(/-/g, " ")
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((raw, i) => {
+      const word = raw.toLowerCase();
+      if (ACRONYMS.has(word)) return word.toUpperCase();
+      if (i > 0 && MINOR_WORDS.has(word)) return word;
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(" ");
+}


### PR DESCRIPTION
First milestone of the UX rework (full review and plan in the maintainer thread). Theme: **make the surface tell the truth about the product** before the community is invited in.

## What changed

### The product finally says what it is
- Hero: "Walk into class with questions worth asking" replaces the generic AI-guide copy; primary CTA is **Find your syllabus**, AI Chat is no longer a hero action
- Feature cards describe the real features (Guided Brainstorm, Question Sheet, Journey + exam runway)
- Footer: fake Terms/Privacy links removed; real Ecosystem column (WikiSyllabus, μLearn, Purple Movement); honest MIT line

### Names and data honesty
- New `titleCase()` util: no more ALL CAPS universities or raw slugs in breadcrumbs; consistent title casing everywhere
- Every subject page carries "Spotted an error? This syllabus is a markdown file on WikiSyllabus. Fix it there" linking to the exact semester folder: the contribution flywheel, one click from where errors are noticed

### Wizard fixes
- **Bug**: first tap on a semester card silently did nothing (`submit()` read `sem` state before React applied it). Now the id is passed directly
- Single-option Scheme step auto-skips (choosing from one option is not a decision)
- Semester gaps (e.g. KTU 2024 starting at S3) get an explanation + WikiSyllabus CTA instead of silent absence
- Selection is remembered; step 1 shows "Continue where you left off" (groundwork for the M2 My Semester home)
- Fake 600-800ms delays trimmed to 200ms

### AI honesty and cost
- **Model selector lied to students**: `gpt-oss-120b` was labeled "GPT 5", `gpt-oss-20b` "GPT 4.1". Labels are now honest, and the selector is hidden in the brainstorm entirely (pedagogy, not knobs)
- Syllabus summary no longer fires an AI call on every subject page view. It is on-demand, cached on the device, and prompted to one tight paragraph + three outcome bullets, never "Not specified" boilerplate
- Removed the keyword blocklist from the summarize flow (same Phase 0 principle as PR #79)

### Titles and metadata
- Root layout title template + honest description; real metadata on /select; `document.title` on subject/brainstorm/journey/teach pages. Full crawler-grade SSR metadata needs the server-component refactor and ships with M2

### Misc
- `alert()` → toast, aria-label on the icon-only send button, foundation chips get an explanatory tooltip
- Exports the `Submission` interface (same one-liner as #90 so CI is green whichever merges first)

## Verified
- `tsc --noEmit` (web) and `tsc -b` (server) pass; `next build` compiles all routes
- Post-merge: I will re-run the full browser walkthrough on the beta deployment

## What this deliberately does not do
No design-system overhaul, no dashboard, no a11y sweep: those are Milestones 2-3, tracked in the maintainer task list, landing as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)