### PR TITLE
fix(brainstorm): Send to class never fails silently

### DIFF
--- a/apps/server/src/routes/classroom/index.ts
+++ b/apps/server/src/routes/classroom/index.ts
@@ -26,7 +26,7 @@ interface ClassroomMeta {
   createdAt: number;
 }
 
-interface Submission {
+export interface Submission {
   module: string;
   questions: string[];
   at: number;

--- a/apps/web/src/app/brainstorm/page.tsx
+++ b/apps/web/src/app/brainstorm/page.tsx
@@ -167,7 +167,14 @@ export default function BrainstormPage() {
 
   const sendToClass = async () => {
     const code = classCode.trim().toUpperCase();
-    if (!code || !sheet.length || sending) return;
+    if (!sheet.length || sending) return;
+    // Never fail silently: say exactly what is missing.
+    if (code.length < 6) {
+      toast.error(
+        "Class codes are 6 characters (like KM6ZJ8). Your teacher gets one by creating a classroom on the For Teachers page."
+      );
+      return;
+    }
     setSending(true);
     try {
       await orpc.classroom.submit.call({
@@ -388,25 +395,40 @@ export default function BrainstormPage() {
             </ul>
 
             {sheet.length > 0 && (
-              <div className="flex gap-2 items-center border-t border-border/50 pt-3">
-                <input
-                  value={classCode}
-                  onChange={(e) => setClassCode(e.target.value.toUpperCase())}
-                  placeholder="Class code"
-                  maxLength={6}
-                  className="w-24 text-xs font-mono tracking-widest rounded-lg border border-border/60 bg-background px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/40"
-                />
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-8 flex-1"
-                  disabled={classCode.trim().length < 6 || sending}
-                  onClick={sendToClass}
-                  title="Send your questions to your teacher, anonymously"
-                >
-                  <Send className="h-3.5 w-3.5 mr-1" />
-                  {sending ? "Sending…" : "Send to class"}
-                </Button>
+              <div className="border-t border-border/50 pt-3 space-y-1.5">
+                <div className="flex gap-2 items-center">
+                  <input
+                    value={classCode}
+                    onChange={(e) => setClassCode(e.target.value.toUpperCase())}
+                    placeholder="Class code"
+                    maxLength={6}
+                    aria-label="6-character class code from your teacher"
+                    className="w-24 text-xs font-mono tracking-widest rounded-lg border border-border/60 bg-background px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/40"
+                  />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8 flex-1"
+                    disabled={sending}
+                    onClick={sendToClass}
+                    title="Send your questions to your teacher, anonymously"
+                  >
+                    <Send className="h-3.5 w-3.5 mr-1" />
+                    {sending ? "Sending…" : "Send to class"}
+                  </Button>
+                </div>
+                <p className="text-[11px] text-muted-foreground">
+                  {classCode.trim().length > 0 && classCode.trim().length < 6
+                    ? `${6 - classCode.trim().length} more character${
+                        6 - classCode.trim().length === 1 ? "" : "s"
+                      } to go. `
+                    : ""}
+                  Sending is anonymous. Teachers create the 6-character code on{" "}
+                  <Link href="/teach" className="underline hover:text-primary">
+                    the For Teachers page
+                  </Link>
+                  .
+                </p>
               </div>
             )}
 


### PR DESCRIPTION
Field report from the maintainer: typed a code into the Question Sheet's class-code box, button stayed dead, no explanation. Classic disabled-control-without-feedback.

## What changed
- Button is no longer disabled by code length; clicking with a short code explains exactly what a class code is and where it comes from
- Live "N more characters to go" hint under the field while typing
- Permanent one-liner: sending is anonymous, teachers mint codes on the For Teachers page (linked)
- aria-label on the code input

## Note for testing
A code only works if a teacher actually created that classroom on /teach (server returns "That classroom code doesn't exist" otherwise, which now surfaces as a toast). Standalone branch off main; merges independently of #90/#91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)