### PR TITLE
UX Milestone 2: My Semester, a home instead of a gate

### DIFF
--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/page.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/page.tsx
@@ -3,7 +3,15 @@
 import { notFound } from "next/navigation";
 import { titleCase } from "@/lib/utils";
 import { useRouter } from "next/navigation";
-import { useState, use } from "react";
+import { useState, use, useEffect } from "react";
+import Link from "next/link";
+import {
+  saveLastSelection,
+  loadJourney,
+  getStreak,
+  daysUntil,
+  Journey,
+} from "@/lib/journey";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import {
@@ -18,8 +26,11 @@ import { Button } from "@/components/ui/button";
 import {
   ArrowRight,
   BookText,
+  CalendarClock,
   Code,
+  Flame,
   FlaskConical,
+  ListChecks,
   Sigma,
 } from "lucide-react";
 import ErrorDisplay from "@/components/ErrorDisplay";
@@ -95,18 +106,65 @@ export default function SubjectsPage({ params }: SubjectsPageProps) {
   const router = useRouter();
   const resolvedParams = use(params);
   const [loadingSubject, setLoadingSubject] = useState<string | null>(null);
+  const [journey, setJourney] = useState<Journey | null>(null);
+  const [streak, setStreak] = useState(0);
   const { data, isFetching, isError, error } = useUniversityData(
     resolvedParams.university
   );
 
-  const handleViewSyllabus = async (subjectId: string, subjectName: string) => {
+  // This page IS the returning student's home. Landing here (wizard or
+  // deep link alike) makes it the remembered semester, and the journey
+  // data enriches the subject cards.
+  useEffect(() => {
+    if (!data) return;
+    const ok =
+      data[resolvedParams.university]?.[resolvedParams.program]?.[
+        resolvedParams.scheme
+      ]?.[resolvedParams.semester];
+    if (!ok) return;
+    saveLastSelection({
+      university: resolvedParams.university,
+      program: resolvedParams.program,
+      scheme: resolvedParams.scheme,
+      semester: resolvedParams.semester,
+    });
+    setJourney(loadJourney());
+    setStreak(getStreak());
+    document.title = `${formatSemesterName(resolvedParams.semester)} · ${titleCase(
+      resolvedParams.program
+    )} | Beyond Syllabus`;
+  }, [data, resolvedParams]);
+
+  const handleViewSyllabus = (subjectId: string, subjectName: string) => {
     setLoadingSubject(subjectId);
-
-    await new Promise((resolve) => setTimeout(resolve, 700));
-
     router.push(
       `/${resolvedParams.university}/${resolvedParams.program}/${resolvedParams.scheme}/${resolvedParams.semester}/${subjectId}`
     );
+  };
+
+  // Cross-reference a subject's modules with the local journey
+  const subjectProgress = (subject: any) => {
+    if (!journey) return null;
+    const titles: string[] = (subject.modules || [])
+      .map((m: any) => m.title)
+      .filter(Boolean);
+    if (!titles.length) return null;
+    let touched = 0;
+    let solid = 0;
+    let shaky = 0;
+    for (const t of titles) {
+      const prog = journey.modules[t];
+      if (prog) {
+        touched += 1;
+        if (prog.status === "solid") solid += 1;
+        if (prog.status === "shaky") shaky += 1;
+      }
+    }
+    const exam = journey.exams.find(
+      (e) => e.subject === titleCase(subject.name)
+    );
+    const examDays = exam ? daysUntil(exam.date) : null;
+    return { total: titles.length, touched, solid, shaky, examDays };
   };
 
   if (isFetching) {
@@ -173,6 +231,23 @@ export default function SubjectsPage({ params }: SubjectsPageProps) {
               <p className="text-muted-foreground mt-2 text-lg">
                 {program.name} ({scheme.name}) &middot; {university.name}
               </p>
+              {journey && Object.keys(journey.modules).length > 0 && (
+                <div className="flex flex-wrap items-center gap-3 mt-4 text-sm">
+                  <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-orange-500/10 text-orange-600 dark:text-orange-400">
+                    <Flame className="h-4 w-4" /> {streak} day streak
+                  </span>
+                  <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-primary/10 text-primary">
+                    <ListChecks className="h-4 w-4" />{" "}
+                    {Object.keys(journey.modules).length} modules touched
+                  </span>
+                  <Link
+                    href="/journey"
+                    className="text-muted-foreground underline hover:text-primary"
+                  >
+                    Full journey
+                  </Link>
+                </div>
+              )}
             </div>
 
             {semester.subjects.length > 0 ? (
@@ -180,6 +255,7 @@ export default function SubjectsPage({ params }: SubjectsPageProps) {
                 {semester.subjects.map((subject: any) => {
                   const category = getSubjectCategory(subject.code);
                   const isLoading = loadingSubject === subject.id;
+                  const progress = subjectProgress(subject);
                   return (
                     <Card
                       key={subject.id}
@@ -199,6 +275,36 @@ export default function SubjectsPage({ params }: SubjectsPageProps) {
                           </Badge>
                         </div>
                         <CardDescription>{subject.code}</CardDescription>
+                        {progress && (
+                          <div className="pt-1 space-y-1.5">
+                            {progress.examDays !== null && progress.examDays >= 0 && (
+                              <span
+                                className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full ${
+                                  progress.examDays <= 3
+                                    ? "bg-red-500/10 text-red-600 dark:text-red-400"
+                                    : "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                                }`}
+                              >
+                                <CalendarClock className="h-3 w-3" /> exam{" "}
+                                {progress.examDays === 0
+                                  ? "today"
+                                  : `in ${progress.examDays}d`}
+                              </span>
+                            )}
+                            {progress.touched > 0 ? (
+                              <p className="text-[11px] text-muted-foreground">
+                                {progress.touched}/{progress.total} modules
+                                touched
+                                {progress.solid > 0 && ` · ${progress.solid} solid`}
+                                {progress.shaky > 0 && ` · ${progress.shaky} shaky`}
+                              </p>
+                            ) : (
+                              <p className="text-[11px] text-muted-foreground/70">
+                                Untouched. Brainstorm a module to start.
+                              </p>
+                            )}
+                          </div>
+                        )}
                       </CardHeader>
                       <CardFooter>
                         <Button

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { getLastSelection, LastSelection } from "@/lib/journey";
+import { titleCase } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { GraduationCap, BookOpenCheck, BarChart3, ChevronRight, Sparkles } from "lucide-react";
@@ -15,6 +17,15 @@ import { Spinner } from "@/components/ui/spinner";
 export default function Home() {
   const router = useRouter();
   const [loadingRoute, setLoadingRoute] = useState<string | null>(null);
+  const [lastSel, setLastSel] = useState<LastSelection | null>(null);
+
+  useEffect(() => {
+    setLastSel(getLastSelection());
+  }, []);
+
+  const semesterPath = lastSel
+    ? `/${lastSel.university}/${lastSel.program}/${lastSel.scheme}/${lastSel.semester}`
+    : null;
 
   const navigateWithDelay = async (path: string, delay: number): Promise<void> => {
     setLoadingRoute(path);
@@ -51,26 +62,40 @@ export default function Home() {
             </p>
 
             <div className="flex flex-col md:flex-row justify-center gap-4 mt-8 ">
-              <Button
-                size="lg"
-                className="group shadow-lg w-full md:w-auto h-[44px] bg-[#8800ff]"
-                asChild
-                disabled={loadingRoute === "/select"}
-              >
-                <Link href="/select" onClick={() => navigateWithDelay("/select", 300)}>
-                  {loadingRoute ? (
-                    <>
-                      <Spinner className="h-5 w-5 mr-2" />
-                      Loading...
-                    </>
-                  ) : (
-                    <>
-                      Find your syllabus
-                      <ChevronRight className="h-5 w-5 ml-2 group-hover:translate-x-1 transition-transform" />
-                    </>
-                  )}
-                </Link>
-              </Button>
+              {semesterPath ? (
+                <Button
+                  size="lg"
+                  className="group shadow-lg w-full md:w-auto h-[44px] bg-[#8800ff]"
+                  asChild
+                >
+                  <Link href={semesterPath}>
+                    Continue: {titleCase(lastSel!.program)} · Sem{" "}
+                    {lastSel!.semester.replace(/\D/g, "")}
+                    <ChevronRight className="h-5 w-5 ml-2 group-hover:translate-x-1 transition-transform" />
+                  </Link>
+                </Button>
+              ) : (
+                <Button
+                  size="lg"
+                  className="group shadow-lg w-full md:w-auto h-[44px] bg-[#8800ff]"
+                  asChild
+                  disabled={loadingRoute === "/select"}
+                >
+                  <Link href="/select" onClick={() => navigateWithDelay("/select", 300)}>
+                    {loadingRoute ? (
+                      <>
+                        <Spinner className="h-5 w-5 mr-2" />
+                        Loading...
+                      </>
+                    ) : (
+                      <>
+                        Find your syllabus
+                        <ChevronRight className="h-5 w-5 ml-2 group-hover:translate-x-1 transition-transform" />
+                      </>
+                    )}
+                  </Link>
+                </Button>
+              )}
 
               <Button
                 asChild
@@ -84,6 +109,15 @@ export default function Home() {
                 </Link>
               </Button>
             </div>
+
+            {semesterPath && (
+              <p className="text-sm text-muted-foreground mt-4">
+                Different course?{" "}
+                <Link href="/select" className="underline hover:text-primary">
+                  Find another syllabus
+                </Link>
+              </p>
+            )}
 
             <p className="text-sm text-muted-foreground mt-6">
               Free and open source. No account needed. Built on{" "}

--- a/apps/web/src/app/select/_components/SelectionForm.tsx
+++ b/apps/web/src/app/select/_components/SelectionForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -60,6 +60,39 @@ export function SelectionForm() {
   const [isLoading, setIsLoading] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState("");
   const [lastSelection] = useState(() => getLastSelection());
+  const hydratedFromUrl = useRef(false);
+
+  // Breadcrumbs across the app link here with ?university=&program=&scheme=.
+  // Honor them: land the visitor on the right step with state restored,
+  // instead of silently resetting to step 1.
+  useEffect(() => {
+    if (hydratedFromUrl.current) return;
+    if (!universities || !universities.length) return;
+    const q = new URLSearchParams(window.location.search);
+    const qu = q.get("university");
+    if (!qu || !universities.includes(qu)) return;
+    hydratedFromUrl.current = true;
+    const qp = q.get("program");
+    const qsch = q.get("scheme");
+    (async () => {
+      setIsLoading(true);
+      setLoadingMessage("Restoring your place...");
+      await ensureUniversity(qu);
+      setU(qu);
+      if (qp && qsch) {
+        setP(qp);
+        setSch(qsch);
+        setStep(4);
+      } else if (qp) {
+        setP(qp);
+        setStep(3);
+      } else {
+        setStep(2);
+      }
+      setIsLoading(false);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [universities]);
 
   const steps = ["University", "Program", "Scheme", "Semester"];
 

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ThemeToggle } from "./ThemeToggle";
+import { MySemesterLink } from "./MySemesterLink";
 
 export function Header() {
   return (
@@ -11,7 +12,14 @@ export function Header() {
           </h6>
         </Link>
 
-        <div className="flex items-center gap-2 ">
+        <div className="flex items-center gap-4">
+          <MySemesterLink />
+          <Link
+            href="/journey"
+            className="hidden sm:inline text-sm font-medium text-muted-foreground hover:text-primary transition-colors"
+          >
+            Journey
+          </Link>
           <ThemeToggle />
         </div>
       </div>

--- a/apps/web/src/components/MySemesterLink.tsx
+++ b/apps/web/src/components/MySemesterLink.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { Map } from "lucide-react";
+import { getLastSelection, LastSelection } from "@/lib/journey";
+import { titleCase } from "@/lib/utils";
+
+/**
+ * Header shortcut to the student's own semester. Renders nothing until a
+ * course has been chosen once (local-first: the selection lives on the
+ * device, no account involved).
+ */
+export function MySemesterLink() {
+  const [sel, setSel] = useState<LastSelection | null>(null);
+
+  useEffect(() => {
+    setSel(getLastSelection());
+  }, []);
+
+  if (!sel) return null;
+
+  return (
+    <Link
+      href={`/${sel.university}/${sel.program}/${sel.scheme}/${sel.semester}`}
+      className="hidden sm:flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-primary transition-colors"
+      title={`${titleCase(sel.program)} · Semester ${sel.semester.replace(/\D/g, "")}`}
+    >
+      <Map className="h-4 w-4" />
+      My semester
+    </Link>
+  );
+}


### PR DESCRIPTION
The flagship change from the UX review: a student has one course for six months, but the app re-interrogated everyone through the four-step wizard on every visit. Now the app has a home.

## How it works
- **Any successful visit to a semester page makes it "my semester"** (saved on-device via the journey store). Wizard and shared deep links both count, so the system self-heals whichever way a student arrives
- **Returning visitors**: the landing page's primary CTA becomes `Continue: <program> · Sem N`, going straight to their subjects. "Find another syllabus" demotes to a text link. First-time visitors see the original wizard CTA unchanged
- **Header** gains "My semester" and "Journey" links (render only when relevant; local-first, no account)

## The semester page earns the job
- Streak + modules-touched strip with a link to the full Journey
- Each subject card shows where you stand: `3/5 modules touched · 1 solid · 1 shaky`, an `exam in Nd` countdown badge when a runway exists, and a gentle "Untouched. Brainstorm a module to start." nudge otherwise
- Real page titles (`Semester 3 · Artificial Intelligence and Data Science`)

## Also fixed in passing
- Breadcrumb links into the wizard carry `?step=&university=&program=&scheme=` but the form never read them: every breadcrumb click silently reset to step 1. The wizard now restores state from those params
- Removed a 700ms artificial delay on subject navigation

## Verified
- `tsc --noEmit` + `next build` clean
- Live browser run against a local server: visited a semester page, confirmed the landing page flipped to Continue mode, confirmed breadcrumb restoration lands on the right wizard step with state intact, confirmed per-subject journey lines render

## Not in this PR
Crawler-grade SSR metadata for syllabus routes needs the pages converted to server components; that refactor is queued next so it gets its own reviewable diff. A11y and mobile passes are Milestone 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)