### PR TITLE
UX Milestone 3: accessibility and mobile ergonomics

### DIFF
--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/CourseModules.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/[subject]/_components/CourseModules.tsx
@@ -89,7 +89,7 @@ export function CourseModules({ modules }: CourseModulesProps) {
           <p className="mt-4 text-muted-foreground">
             No modules found for this syllabus.
           </p>
-          <p className="text-sm text-muted-foreground/80">
+          <p className="text-sm text-muted-foreground">
             The content might be under preparation.
           </p>
         </div>
@@ -163,7 +163,7 @@ export function CourseModules({ modules }: CourseModulesProps) {
                           type="button"
                           title="Saved on this device only. Feeds your Journey page and exam runway."
                           onClick={() => updateStatus(module.title!, opt.id)}
-                          className={`text-[11px] px-2.5 py-1 rounded-full border transition-colors ${
+                          className={`text-[11px] px-2.5 py-1 rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
                             statuses[module.title!] === opt.id
                               ? opt.active
                               : "border-border/60 text-muted-foreground hover:bg-muted"

--- a/apps/web/src/app/[university]/[program]/[scheme]/[semester]/page.tsx
+++ b/apps/web/src/app/[university]/[program]/[scheme]/[semester]/page.tsx
@@ -299,7 +299,7 @@ export default function SubjectsPage({ params }: SubjectsPageProps) {
                                 {progress.shaky > 0 && ` · ${progress.shaky} shaky`}
                               </p>
                             ) : (
-                              <p className="text-[11px] text-muted-foreground/70">
+                              <p className="text-[11px] text-muted-foreground">
                                 Untouched. Brainstorm a module to start.
                               </p>
                             )}

--- a/apps/web/src/app/brainstorm/page.tsx
+++ b/apps/web/src/app/brainstorm/page.tsx
@@ -325,7 +325,7 @@ export default function BrainstormPage() {
                     key={q}
                     type="button"
                     onClick={() => addToSheet(q, "ai")}
-                    className="text-left text-xs px-3 py-1.5 rounded-xl border border-primary/30 bg-primary/5 hover:bg-primary/15 transition-colors"
+                    className="text-left text-xs px-3 py-1.5 rounded-xl border border-primary/30 bg-primary/5 hover:bg-primary/15 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                   >
                     <Plus className="h-3 w-3 inline mr-1" />
                     {q}
@@ -361,6 +361,7 @@ export default function BrainstormPage() {
                 disabled={!sheet.length}
                 onClick={exportSheet}
                 title="Download as markdown"
+                aria-label="Download question sheet as markdown"
               >
                 <Download className="h-4 w-4" />
               </Button>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -27,7 +27,7 @@
   --secondary-foreground: 220 14.3% 34.3%;
 
   --muted: 220 13% 91%;
-  --muted-foreground: 220 8.9% 43.1%;
+  --muted-foreground: 220 10% 36%;
 
   --accent: 262.1 83.3% 75%;
   --accent-foreground: 0 0% 100%;

--- a/apps/web/src/app/select/_components/SelectionForm.tsx
+++ b/apps/web/src/app/select/_components/SelectionForm.tsx
@@ -19,7 +19,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Info, BookOpen } from "lucide-react";
@@ -174,7 +173,7 @@ export function SelectionForm() {
         </CardDescription>
       </CardHeader>
 
-        <CardContent className="space-y-4 flex items-center justify-center min-h-[300px] px-4">
+        <CardContent className="space-y-4 flex items-center justify-center min-h-[220px] md:min-h-[300px] px-4">
         <AnimatePresence mode="wait">
           {isLoading ? (
             <MotionDiv
@@ -212,7 +211,7 @@ export function SelectionForm() {
                             `/${lastSelection.university}/${lastSelection.program}/${lastSelection.scheme}/${lastSelection.semester}`
                           )
                         }
-                        className="w-[280px] text-left p-3 rounded-xl border border-primary/40 bg-primary/5 hover:bg-primary/10 transition-colors"
+                        className="w-full max-w-[320px] text-left p-3 rounded-xl border border-primary/40 bg-primary/5 hover:bg-primary/10 transition-colors"
                       >
                         <p className="text-xs text-muted-foreground">Continue where you left off</p>
                         <p className="text-sm font-semibold">
@@ -228,10 +227,10 @@ export function SelectionForm() {
                         )
                       }
                     >
-                      <SelectTrigger className="w-[280px] py-3 px-3 rounded-xl border border-purple-300 bg-white dark:bg-gray-900 shadow-sm">
+                      <SelectTrigger className="w-full max-w-[320px] py-3 px-3 rounded-xl border border-purple-300 bg-white dark:bg-gray-900 shadow-sm">
                         <SelectValue placeholder="Choose a university" />
                       </SelectTrigger>
-                      <SelectContent className="w-[280px] rounded-xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 shadow-lg max-h-[200px] overflow-y-auto">
+                      <SelectContent className="w-full max-w-[320px] rounded-xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 shadow-lg max-h-[200px] overflow-y-auto">
                         {[...universities]
                           .sort((a, b) => cap(a).localeCompare(cap(b)))
                           .map((id) => (
@@ -265,10 +264,10 @@ export function SelectionForm() {
                         }
                       }}
                     >
-                      <SelectTrigger className="w-[280px] py-3 px-3 rounded-xl border border-purple-300 bg-white dark:bg-gray-900 shadow-sm">
+                      <SelectTrigger className="w-full max-w-[320px] py-3 px-3 rounded-xl border border-purple-300 bg-white dark:bg-gray-900 shadow-sm">
                         <SelectValue placeholder="Select Program" />
                       </SelectTrigger>
-                      <SelectContent className="w-[280px] rounded-xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 shadow-lg max-h-[200px] overflow-y-auto">
+                      <SelectContent className="w-full max-w-[320px] rounded-xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 shadow-lg max-h-[200px] overflow-y-auto">
                         {Object.keys(uniData)
                           .sort((a, b) => cap(a).localeCompare(cap(b)))
                           .map((id) => (
@@ -305,7 +304,7 @@ export function SelectionForm() {
                           key={id}
                           type="button"
                           className={cn(
-                            "p-4 rounded-lg border-2 transition hover:shadow-lg hover:bg-purple-500 cursor-pointer",
+                            "p-4 rounded-lg border-2 transition hover:shadow-lg hover:bg-primary/15 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
                             sch === id ? "border-primary bg-primary/10" : "border-purple-700"
                           )}
                           onClick={() => loadStep("Loading semesters...", 4, () => setSch(id))}
@@ -321,14 +320,17 @@ export function SelectionForm() {
               {step === 4 && schemeData && (
                 <MotionDiv key="step4" variants={stepVariants} initial="hidden" animate="visible" exit="exit" className="space-y-3 w-full">
                   <Label className="text-center block font-semibold">4. Pick Semester</Label>
-                    <RadioGroup value={sem ?? ""} className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
                       {Object.keys(schemeData)
                         .sort((a, b) => semNum(a) - semNum(b))
                         .map((id) => (
-                          <div
+                          <button
                             key={id}
+                            type="button"
+                            aria-label={`Open ${semName(id)}`}
                             className={cn(
-                              "rounded-lg p-4 border-2 hover:shadow-lg hover:bg-purple-500 transition cursor-pointer",
+                              "rounded-lg p-4 border-2 transition cursor-pointer hover:shadow-lg hover:bg-primary/15",
+                              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
                               sem === id ? "border-primary bg-primary/10" : "border-purple-700"
                             )}
                             onClick={() => {
@@ -336,12 +338,11 @@ export function SelectionForm() {
                               submit(id);
                             }}
                           >
-                            <RadioGroupItem value={id} className="sr-only" />
                             <BookOpen className="h-5 w-5 mb-1 mx-auto" />
                             <p className="text-xs font-semibold text-center">{semName(id)}</p>
-                          </div>
+                          </button>
                         ))}
-                    </RadioGroup>
+                    </div>
                     {(() => {
                       const nums = Object.keys(schemeData)
                         .map(semNum)

--- a/apps/web/src/components/Breadcrumbs.tsx
+++ b/apps/web/src/components/Breadcrumbs.tsx
@@ -1,11 +1,24 @@
 import Link from "next/link";
 import { Fragment } from "react";
-import { ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { BreadcrumbsProps } from "@/lib/types";
 
 export function Breadcrumbs({ items }: BreadcrumbsProps) {
+  // On phones the full trail does not fit; a single "back one level" link
+  // beats no navigation at all (which is what hidden md:flex used to mean).
+  const parent = [...items].reverse().find((item, i) => i > 0 && item.href);
+
   return (
     <nav aria-label="Breadcrumb">
+      {parent && (
+        <Link
+          href={parent.href!}
+          className="md:hidden inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-primary transition-colors"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          {parent.label}
+        </Link>
+      )}
       <ol className="hidden md:flex items-center space-x-2 text-sm text-muted-foreground">
         {items.map((item, index) => (
           <Fragment key={item.label}>

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -22,6 +22,9 @@ export function ThemeToggle() {
       variant="ghost"
       type="button"
       size="icon"
+      aria-label={
+        resolvedTheme === "dark" ? "Switch to light theme" : "Switch to dark theme"
+      }
       className="p-3 sm:p-4 rounded-full transition-transform duration-300 hover:scale-105"
       onClick={() => {
         setTheme(resolvedTheme === "light" ? "dark" : "light");


### PR DESCRIPTION
Third milestone of the UX rework. Small diff, but it is the difference between "works on my machine" and works for everyone.

## Accessibility
- **Semester tiles were unreachable by keyboard**: plain `div`s with `onClick`, invisible to screen readers. Converted to real `<button>`s with aria-labels and visible focus rings
- Focus-visible rings added to every raw-button surface: scheme tiles, module status chips (Shaky / Getting there / Solid), AI-suggested question chips
- Theme toggle now announces "Switch to light/dark theme"; sheet download button labeled
- Light-mode muted text darkened (43% -> 36% lightness): it was borderline WCAG AA at the small sizes it is used at. Removed `/70` and `/80` opacity dilutions on small text for the same reason
- Hover state on tiles no longer flips to `purple-500` behind dark text (contrast inversion)

## Mobile
- Breadcrumbs were `hidden md:flex`: phones had **no** trail navigation at all. A back-one-level link (`< Semester 3`) now renders below md
- Wizard controls go full-width on phones, dead vertical space reduced

## Verified
- `tsc --noEmit` + `next build` clean
- Live 375px-viewport run: back-crumb on semester and subject pages, "Switch to light theme" visible in the accessibility tree, densified wizard confirmed by screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)