### PR TITLE
UX Milestone 4: governance for the community handoff

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Syllabus content is wrong or missing
+    url: https://github.com/The-Purple-Movement/WikiSyllabus
+    about: Subjects, modules, semesters, and past papers live in WikiSyllabus. One markdown file there fixes it here for everyone.
+  - name: The Purple Movement
+    url: https://github.com/The-Purple-Movement
+    about: The wider ecosystem this app belongs to.

--- a/.github/ISSUE_TEMPLATE/ux_finding.yml
+++ b/.github/ISSUE_TEMPLATE/ux_finding.yml
@@ -1,0 +1,47 @@
+name: UX finding
+description: Something in the interface is confusing, misleading, inaccessible, or broken as an experience
+title: "[UX] "
+labels: ["ux"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for looking closely. UX findings are reviewed against [DESIGN.md](../blob/main/DESIGN.md);
+        if you can name the principle being violated, even better, but a plain description is enough.
+  - type: input
+    id: screen
+    attributes:
+      label: Where
+      description: URL or screen (e.g. /select step 4, subject page, brainstorm sheet)
+      placeholder: /brainstorm question sheet
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      placeholder: I typed a class code and expected the button to respond or tell me what was wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened instead
+      placeholder: The button stayed grey with no explanation.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshot or recording
+      description: Drag an image here. On phones, include the device if you know it.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: How much does it hurt?
+      options:
+        - Blocks the task entirely
+        - Confusing but there is a workaround
+        - Cosmetic or polish
+    validations:
+      required: true

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-Welcome to my portfolio website! We appreciate your interest in contributing to my project. By contributing, you help me create a better software for everyone.
+Welcome to Beyond Syllabus, the Purple Movement's flipped-classroom app built on WikiSyllabus, the open syllabus commons. By contributing you help every student who walks into class with questions worth asking.
 
 Before you start contributing, please take a moment to read the following guidelines to ensure a smooth and effective contribution process.
 
@@ -53,6 +53,19 @@ Feel free to pick any open issue from our [issue tracker](https://github.com/The
 6. Be willing to make any requested changes or improvements.
 
 ---
+
+## Contributing UX and design
+
+UI changes are reviewed against [DESIGN.md](./DESIGN.md), our written design
+principles. Read it before starting; it is short and it is the review bar.
+
+- Found a UX problem? Open an issue with the **UX finding** template:
+  say what you expected, what happened, and attach a screenshot.
+- Want to fix one? Comment on the issue, then send a PR that passes the
+  checklist at the bottom of DESIGN.md.
+- Syllabus content problems (wrong module, missing semester) belong in
+  [WikiSyllabus](https://github.com/The-Purple-Movement/WikiSyllabus), the
+  data source: every subject page links to its exact source folder.
 
 ## 🤝 Code of Conduct
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,96 @@
+# Design Principles
+
+These are the principles UI changes are reviewed against. They exist so a
+contributor can design confidently without waiting for a maintainer's taste,
+and so review feedback is grounded in something written rather than opinion.
+If a PR and a principle disagree, either the PR changes or this file does,
+by discussion, never silently.
+
+## 1. The surface tells the truth
+
+- No fake links (a "Privacy Policy" that points at the repo root is a lie).
+- No dishonest labels: models are named what they are, counts are real,
+  "coming soon" is said out loud.
+- Data-derived names are humanized (`titleCase`), never raw slugs or
+  ALL CAPS folder names.
+
+## 2. Brainstorm first, chat second
+
+The product exists to help students walk into class with questions worth
+asking. "Brainstorm before class" is the primary action wherever both
+appear; open-ended AI chat is the secondary path. Any change that inverts
+this hierarchy is a regression, however pretty.
+
+## 3. A home, not a gate
+
+A student has one course for months. Returning users land on their
+semester, not a wizard. The wizard exists for first-run and switching.
+Anything that adds steps between a returning student and their subjects
+needs a very good reason.
+
+## 4. Local-first, no accounts
+
+Learning never requires a login. The journey lives on the device, is
+exportable, and the UI says so plainly. Do not add features that only work
+with accounts; design them local-first with sync as a later layer.
+
+## 5. Data gaps are invitations
+
+Beyond Syllabus renders WikiSyllabus. Where data is missing (a semester, a
+subject, a past paper), the UI says what is missing and links to where one
+markdown file fixes it for everyone. Silent absence wastes the gap;
+an error message wastes the contributor.
+
+## 6. Never fail silently
+
+A disabled control explains what would enable it. An empty state says what
+belongs there and how it gets there. Every async action has a pending
+state. `alert()` is banned; use toasts with sentences a student would
+understand.
+
+## 7. Accessibility is the floor, not a feature
+
+- Every interactive element is a real `<button>`, `<a>`, or input:
+  reachable by keyboard, visible focus ring, announced by screen readers.
+- Text meets WCAG AA contrast at the size it is used. Do not dilute
+  `muted-foreground` with opacity modifiers on small text.
+- Icon-only buttons carry `aria-label`.
+
+## 8. Phones are the primary device
+
+Most students are on phones. Layouts are designed at 375px first and
+enhanced upward. Navigation must exist at every breakpoint (no
+`hidden md:flex` without a mobile equivalent).
+
+## 9. The AI is a coach, not a dependency
+
+AI output is generated on demand, cached where sensible, and never blocks
+the core reading experience. Offline states coach the student through the
+same exercise manually. No auto-firing AI calls on page view. No walls of
+generated boilerplate: if a summary reads the same for every subject, it
+is not a summary.
+
+## 10. Speed is respect
+
+No artificial delays. No spinner theater. If something is fast, let it be
+fast; if something is slow, show honest progress.
+
+---
+
+## Copy voice
+
+Plain, direct, warm. Write like a good senior explaining to a first-year:
+no marketing verbs ("unlock", "streamline", "empower"), no exclamation
+inflation. Say what a thing does and why a student would care.
+
+## PR checklist for UI changes
+
+- [ ] Works at 375px and with keyboard only
+- [ ] Interactive elements are semantic, labeled, and focus-visible
+- [ ] Pending, empty, and error states exist and explain themselves
+- [ ] New copy passes the voice rules above
+- [ ] No new AI call fires without a user action
+- [ ] `bun run typecheck` and `next build` pass
+
+*This file was seeded from the July 2026 UX review (see the pinned "Design
+north star" issue). Amend it by PR like any other file.*


### PR DESCRIPTION
Final milestone of the UX rework: the system is stable (M1-M3 merged), so this opens the doors properly.

## What's in it
- **DESIGN.md**: ten written principles UI changes are reviewed against (truth-telling surfaces, brainstorm-first hierarchy, home-not-gate, local-first, gaps-as-invitations, never-fail-silently, a11y floor, mobile-first, AI-as-coach, no spinner theater), plus copy voice rules and a PR checklist. Contributors can now design without waiting on maintainer taste, and reviews cite principles instead of opinions
- **CONTRIBUTION.md**: the intro still said "Welcome to my portfolio website!" (template leftover); replaced with who we actually are. New UX-contribution section pointing at DESIGN.md and routing data problems to WikiSyllabus
- **UX finding issue template** (where / expected / actual / evidence / severity) auto-labeled `ux`
- **Template config** routing syllabus-content issues to WikiSyllabus

## Alongside this PR (repo settings, done via API)
- New labels: `ux`, `a11y`, `design-system`, `data-quality`
- A pinned **Design north star** issue carrying the condensed UX review and the open follow-ups (SSR metadata refactor, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)