### PR TITLE
Surface the shared first year instead of telling students it is missing

### DIFF
--- a/apps/web/src/app/select/_components/SelectionForm.tsx
+++ b/apps/web/src/app/select/_components/SelectionForm.tsx
@@ -27,6 +27,7 @@ import { useData } from "@/contexts/dataContext";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import { Spinner } from "@/components/ui/spinner";
 import { getLastSelection, saveLastSelection } from "@/lib/journey";
+import { findSharedYearPrograms } from "@/lib/semesters";
 
 const cap = (s?: string) => titleCase(s);
 const semName = (id: string) => `Semester ${id.replace("s", "").replace(/^0+/, "")}`;
@@ -344,13 +345,63 @@ export function SelectionForm() {
                         ))}
                     </div>
                     {(() => {
-                      const nums = Object.keys(schemeData)
-                        .map(semNum)
-                        .sort((a, b) => a - b);
+                      const semesterIds = Object.keys(schemeData);
+                      const nums = semesterIds.map(semNum).sort((a, b) => a - b);
                       const hasGaps =
                         nums.length > 0 &&
                         (nums[0] > 1 || nums[nums.length - 1] - nums[0] + 1 !== nums.length);
-                      return hasGaps ? (
+                      if (!hasGaps) return null;
+
+                      // Some universities publish the first year separately,
+                      // shared across branches (KTU 2024 does this). If a
+                      // sibling program covers the missing early semesters,
+                      // the syllabus is not missing, just filed elsewhere.
+                      const shared =
+                        u && sch
+                          ? findSharedYearPrograms({
+                              programs: directory[u],
+                              currentProgramId: p ?? "",
+                              schemeId: sch,
+                              currentSemesterIds: semesterIds,
+                            })
+                          : [];
+
+                      if (shared.length) {
+                        return (
+                          <div className="pt-2 space-y-2 text-center">
+                            <p className="text-xs text-muted-foreground">
+                              Looking for your first year? At this university it is
+                              shared across branches, so those semesters are
+                              published separately:
+                            </p>
+                            <div className="flex flex-wrap justify-center gap-2">
+                              {shared.map((sp) => (
+                                <button
+                                  key={sp.id}
+                                  type="button"
+                                  onClick={() => {
+                                    setP(sp.id);
+                                    setStep(4);
+                                  }}
+                                  className="text-xs px-3 py-1.5 rounded-full border border-primary/40 text-primary hover:bg-primary/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                                >
+                                  {cap(sp.id)}
+                                  <span className="text-muted-foreground">
+                                    {" "}
+                                    · Sem {sp.semesters.join(", ")}
+                                  </span>
+                                </button>
+                              ))}
+                            </div>
+                            <p className="text-[11px] text-muted-foreground">
+                              Not sure which one is yours? Your university&apos;s scheme
+                              document says which group your branch belongs to.
+                            </p>
+                          </div>
+                        );
+                      }
+
+                      return (
                         <p className="text-xs text-muted-foreground text-center pt-2">
                           Not seeing your semester? It has not been contributed yet.{" "}
                           <a
@@ -363,7 +414,7 @@ export function SelectionForm() {
                           </a>{" "}
                           and it appears here for everyone.
                         </p>
-                      ) : null;
+                      );
                     })()}
                 </MotionDiv>
               )}

--- a/apps/web/src/lib/semesters.test.ts
+++ b/apps/web/src/lib/semesters.test.ts
@@ -1,0 +1,121 @@
+// Shaped from the real KTU 2024 directory (verified against WikiSyllabus on
+// 2026-07-29): branches publish s03-s08, the common first year is published
+// as group-a..group-d with s01/s02, and semester ids are inconsistently
+// padded (`s3` under one branch, `s03` under another).
+import { describe, expect, it } from "vitest";
+import {
+  findSharedYearPrograms,
+  semesterLabel,
+  semesterNumber,
+} from "./semesters";
+
+const KTU_2024 = {
+  "computer-science-and-design": {
+    "2024": { s03: {}, s04: {}, s05: {}, s06: {}, s07: {}, s08: {} },
+  },
+  "electronics-and-communication-engineering": {
+    // deliberately unpadded, exactly as the repo has it today
+    "2024": { s3: {}, s4: {}, s5: {}, s6: {}, s7: {}, s8: {} },
+  },
+  "group-a": { "2024": { s01: {}, s02: {} } },
+  "group-b": { "2024": { s01: {} } },
+  "group-c": { "2024": { s01: {}, s02: {} } },
+  "group-d": { "2024": { s01: {}, s02: {} } },
+  // An unrelated program that also runs a first semester but overlaps the
+  // branch range: it must NOT be offered as a shared first year.
+  mca: { "2024": { s01: {}, s02: {}, s03: {}, s04: {} } },
+};
+
+describe("semesterNumber / semesterLabel", () => {
+  it("normalizes padded, unpadded, and uppercase ids", () => {
+    expect(semesterNumber("s01")).toBe(1);
+    expect(semesterNumber("s3")).toBe(3);
+    expect(semesterNumber("S05")).toBe(5);
+    expect(semesterLabel("s03")).toBe("Semester 3");
+    expect(semesterLabel("s3")).toBe("Semester 3");
+  });
+
+  it("does not crash on junk", () => {
+    expect(semesterNumber("")).toBe(0);
+    expect(semesterLabel("nonsense")).toBe("nonsense");
+  });
+});
+
+describe("findSharedYearPrograms", () => {
+  it("surfaces the common first year for a branch that starts at semester 3", () => {
+    const found = findSharedYearPrograms({
+      programs: KTU_2024,
+      currentProgramId: "computer-science-and-design",
+      schemeId: "2024",
+      currentSemesterIds: ["s03", "s04", "s05", "s06", "s07", "s08"],
+    });
+    expect(found.map((f) => f.id)).toEqual([
+      "group-a",
+      "group-b",
+      "group-c",
+      "group-d",
+    ]);
+    expect(found[0].semesters).toEqual([1, 2]);
+  });
+
+  it("excludes overlapping programs like MCA", () => {
+    const found = findSharedYearPrograms({
+      programs: KTU_2024,
+      currentProgramId: "computer-science-and-design",
+      schemeId: "2024",
+      currentSemesterIds: ["s03", "s04", "s05", "s06", "s07", "s08"],
+    });
+    expect(found.map((f) => f.id)).not.toContain("mca");
+  });
+
+  it("works when the current program uses unpadded semester ids", () => {
+    const found = findSharedYearPrograms({
+      programs: KTU_2024,
+      currentProgramId: "electronics-and-communication-engineering",
+      schemeId: "2024",
+      currentSemesterIds: ["s3", "s4", "s5", "s6", "s7", "s8"],
+    });
+    expect(found.map((f) => f.id)).toContain("group-c");
+  });
+
+  it("returns nothing when the program already starts at semester 1", () => {
+    expect(
+      findSharedYearPrograms({
+        programs: KTU_2024,
+        currentProgramId: "group-a",
+        schemeId: "2024",
+        currentSemesterIds: ["s01", "s02"],
+      })
+    ).toEqual([]);
+  });
+
+  it("returns nothing when no sibling covers the gap", () => {
+    expect(
+      findSharedYearPrograms({
+        programs: { solo: { "2024": { s03: {}, s04: {} } } },
+        currentProgramId: "solo",
+        schemeId: "2024",
+        currentSemesterIds: ["s03", "s04"],
+      })
+    ).toEqual([]);
+  });
+
+  it("is safe on missing or empty input", () => {
+    expect(
+      findSharedYearPrograms({
+        programs: null,
+        currentProgramId: "x",
+        schemeId: "2024",
+        currentSemesterIds: ["s03"],
+      })
+    ).toEqual([]);
+    expect(
+      findSharedYearPrograms({
+        programs: KTU_2024,
+        currentProgramId: "x",
+        schemeId: "2024",
+        currentSemesterIds: [],
+      })
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/semesters.ts
+++ b/apps/web/src/lib/semesters.ts
@@ -1,0 +1,90 @@
+/**
+ * Semester helpers.
+ *
+ * Some universities do not publish every semester under every branch. KTU's
+ * 2024 scheme is the case that prompted this: semesters 3 to 8 are
+ * branch-specific, but the first year is common across branches and
+ * published separately (as Groups A to D). A student who picks their branch
+ * sees a semester list starting at 3 and concludes their syllabus is
+ * missing, when it is actually sitting under a sibling program whose name
+ * means nothing to them.
+ *
+ * Nothing here hardcodes KTU or the word "group". The signal is structural:
+ * a shared-year program covers the semesters this program is missing and
+ * does not overlap the semesters it already has.
+ */
+
+/** `s01`, `s3`, `S05` all become the number. Returns 0 when unparseable. */
+export function semesterNumber(id: string): number {
+  return Number(String(id).replace(/\D/g, "")) || 0;
+}
+
+/** `s01` and `s3` both render as "Semester 3"-style labels. */
+export function semesterLabel(id: string): string {
+  const n = semesterNumber(id);
+  return n ? `Semester ${n}` : String(id);
+}
+
+export interface SharedYearProgram {
+  /** program id, as used in URLs */
+  id: string;
+  /** the semester ids this program publishes, lowest first */
+  semesterIds: string[];
+  /** those same semesters as numbers, lowest first */
+  semesters: number[];
+}
+
+/**
+ * Find sibling programs that publish the early semesters this program is
+ * missing.
+ *
+ * A sibling qualifies only when it covers at least one missing semester
+ * AND shares no semester with the current program. That complementary
+ * shape is what distinguishes a shared first year (semesters 1 and 2 only)
+ * from an unrelated program that merely also happens to run a semester 1.
+ */
+export function findSharedYearPrograms(args: {
+  /** every program for this university, i.e. directory[universityId] */
+  programs: Record<string, any> | undefined | null;
+  currentProgramId: string;
+  schemeId: string;
+  /** semester ids the current program publishes for this scheme */
+  currentSemesterIds: string[];
+}): SharedYearProgram[] {
+  const { programs, currentProgramId, schemeId, currentSemesterIds } = args;
+  if (!programs) return [];
+
+  const mine = currentSemesterIds.map(semesterNumber).filter(Boolean);
+  if (!mine.length) return [];
+
+  const lowest = Math.min(...mine);
+  if (lowest <= 1) return []; // nothing missing before the start
+
+  const missing: number[] = [];
+  for (let n = 1; n < lowest; n++) missing.push(n);
+
+  const found: SharedYearProgram[] = [];
+  for (const id of Object.keys(programs)) {
+    if (id === currentProgramId) continue;
+    const scheme = programs[id]?.[schemeId];
+    if (!scheme) continue;
+
+    const semesterIds = Object.keys(scheme);
+    const semesters = semesterIds.map(semesterNumber).filter(Boolean);
+    if (!semesters.length) continue;
+
+    const coversMissing = semesters.some((s) => missing.includes(s));
+    const overlapsMine = semesters.some((s) => mine.includes(s));
+    if (coversMissing && !overlapsMine) {
+      found.push({
+        id,
+        semesterIds: [...semesterIds].sort(
+          (a, b) => semesterNumber(a) - semesterNumber(b)
+        ),
+        semesters: [...semesters].sort((a, b) => a - b),
+      });
+    }
+  }
+
+  return found.sort((a, b) => a.id.localeCompare(b.id));
+}

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -21,6 +21,13 @@ describe("titleCase", () => {
     expect(titleCase("the-purple-movement")).toBe("The Purple Movement");
   });
 
+  it("capitalizes a trailing minor word (KTU's group-a would read 'Group a')", () => {
+    expect(titleCase("group-a")).toBe("Group A");
+    expect(titleCase("group-d")).toBe("Group D");
+    // and still lowercases minor words in the middle
+    expect(titleCase("bachelor-of-social-work")).toBe("Bachelor of Social Work");
+  });
+
   it("uppercases known acronyms anywhere", () => {
     expect(titleCase("ai-and-ml-fundamentals")).toBe("AI and ML Fundamentals");
     expect(titleCase("iot-systems")).toBe("IOT Systems");

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -24,10 +24,13 @@ export function titleCase(input?: string): string {
     .replace(/-/g, " ")
     .split(/\s+/)
     .filter(Boolean)
-    .map((raw, i) => {
+    .map((raw, i, all) => {
       const word = raw.toLowerCase();
       if (ACRONYMS.has(word)) return word.toUpperCase();
-      if (i > 0 && MINOR_WORDS.has(word)) return word;
+      // First and last words are always capitalized, per standard title
+      // case. Without the last-word rule "group-a" renders as "Group a".
+      const isEdge = i === 0 || i === all.length - 1;
+      if (!isEdge && MINOR_WORDS.has(word)) return word;
       return word.charAt(0).toUpperCase() + word.slice(1);
     })
     .join(" ");


### PR DESCRIPTION
## The bug

A KTU first-year student picks their branch, sees the semester list start at **Semester 3**, and our own gap message tells them their syllabus "has not been contributed yet" and invites them to go add it on WikiSyllabus.

That message is wrong, and it has been wrong the whole time. KTU's 2024 scheme publishes semesters 3-8 per branch and the **first year separately, shared across branches as Groups A-D**. Those files are already in WikiSyllabus (`group-a` .. `group-d`, with `ucest105`, `gzpht121`, `gccyt122`, `uchwt127`, `gcest103`). The data was never missing. It was filed under a program name no student would think to select, and we were telling them to go recreate it.

I found this while mapping ktu.edu.in for a bulk download, and it is worth more than the download: it is a fix for a student this week, with no new data required.

## The fix

`lib/semesters.ts` → `findSharedYearPrograms()` finds sibling programs that **cover the missing early semesters and share no semester with the current program**. That complementary shape is what separates a shared first year (semesters 1-2 only) from an unrelated program that merely also runs a semester 1 (MCA, which is correctly excluded).

Nothing hardcodes KTU or the word "group". Critically, it also **does not assert which group a branch belongs to**, because KTU does not publish that mapping in the data and I will not invent one that could send a student to the wrong first-year syllabus. The UI offers the groups and says plainly that the scheme document is what answers that question.

Semester ids are compared by number throughout, since the repo currently holds both `s3` and `s03` for the same semester.

When no sibling covers the gap, the original contribute CTA still shows, which is the case where it is actually true.

Also fixes `titleCase` to always capitalize the last word (standard title case). Without it, `group-a` rendered as "Group a".

## Verified

- 19 tests green (7 new in `semesters.test.ts`, shaped from the real KTU directory including the `s3`/`s03` inconsistency and the MCA exclusion case), `tsc --noEmit` and `next build` clean
- Live local run against real data: CSD branch offers the four groups → Group C opens Semesters 1-2 → Semester 1 lists the real first-year courses

## Data bugs found while doing this (not fixed here)

1. **Inconsistent semester padding** in WikiSyllabus: `artificial-intelligence-and-data-science/2024` has `s05 s06 s07 s08 s3 s4`, and `electronics-and-communication-engineering/2024` is entirely unpadded. The validator's `s\d{2}` would reject these; they predate it and CI only validates changed files. This code tolerates both, but the data should be normalized.
2. **`computer-science/2024/s02` exists**, a first-year semester filed under a branch, which contradicts the shared-first-year structure and is probably a misfiled contribution.

Both are WikiSyllabus-side and I will file them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)