### PR TITLE
feat(generate): warn when a semester declares a course code twice

### DIFF
--- a/apps/server/src/routes/syllabus/generate.ts
+++ b/apps/server/src/routes/syllabus/generate.ts
@@ -5,6 +5,12 @@ import matter from "gray-matter";
 
 const universitiesDir = path.join(process.cwd(), "universities");
 
+// Semesters where two files declare the same course code. Collected during
+// the walk and reported at the end, so the list is not buried in the middle
+// of the output. Never fatal: both records are kept and both stay reachable,
+// because subjects are keyed on file name rather than course code.
+const repeatedCodes: string[] = [];
+
 async function readSyllabusData() {
   const data: any = {};
 
@@ -190,6 +196,31 @@ async function readSyllabusData() {
                 ].subjects.push(subjectData);
               }
             }
+
+            // A course code should identify one course within a semester.
+            // When it does not, the semester list shows the same code on two
+            // cards and any lookup by code is ambiguous. Both entries are
+            // still emitted; this only surfaces the clash.
+            const idsByCode = new Map<string, string[]>();
+            for (const subject of data[universityId][programId][schemeId][
+              semesterId
+            ].subjects) {
+              // "N/A" is the placeholder for a missing course_code, so it
+              // would otherwise collide with every other incomplete file.
+              if (!subject.code || subject.code === "N/A") continue;
+              const key = String(subject.code).toLowerCase();
+              const ids = idsByCode.get(key) ?? [];
+              ids.push(subject.id);
+              idsByCode.set(key, ids);
+            }
+            for (const [code, ids] of idsByCode) {
+              if (ids.length > 1) {
+                repeatedCodes.push(
+                  `${universityId}/${programId}/${schemeId}/${semesterId}: ` +
+                    `${code} on ${ids.sort().join(", ")}`
+                );
+              }
+            }
           }
         }
       }
@@ -202,6 +233,18 @@ async function readSyllabusData() {
 
     await Bun.write(outputPath, JSON.stringify(data, null, 2));
     console.log(`✅ Syllabus data generated at ${outputPath}`);
+
+    if (repeatedCodes.length > 0) {
+      console.warn(
+        `⚠️  ${repeatedCodes.length} semester(s) declare a course code twice:`
+      );
+      for (const line of repeatedCodes.sort()) console.warn(`   ${line}`);
+      console.warn(
+        "   Both courses are still generated and both remain reachable. " +
+          "The codes need correcting in WikiSyllabus, where scripts/audit.py " +
+          "reports the same clashes against the source."
+      );
+    }
   } catch (error) {
     console.error("❌ Error generating syllabus data:", error);
     process.exit(1);


### PR DESCRIPTION
Companion to The-Purple-Movement/WikiSyllabus#219. The audit in WikiSyllabus found **15 semesters where two files share a course code**. This surfaces the same clash at build time.

## What it does

After building each semester's subject list, group by course code and report any code carried by more than one file:

```
⚠️  1 semester(s) declare a course code twice:
   testuni/cse/2024/s07: pecst753 on 13, 15
   Both courses are still generated and both remain reachable. The codes need
   correcting in WikiSyllabus, where scripts/audit.py reports the same clashes
   against the source.
```

## Deliberately not fatal

Nothing is dropped and nothing breaks. Subjects are keyed on file name, not course code, so both courses generate and both stay reachable. Failing the build would block every deploy over a pre-existing data backlog that cannot be fixed from this repository.

## The "N/A" trap

`code` falls back to the string `"N/A"` when `course_code` is missing. Grouping naively would make every incomplete file collide with every other incomplete file and produce a huge false report. `"N/A"` is skipped.

## Verified against a fixture

Five files: a duplicate `pecst753` pair, a unique `pecst754`, and two files with no code at all.

```
subjects emitted: 5
  id=13   code=pecst753   name=fuzzy-systems
  id=14   code=pecst754   name=digital-forensics
  id=20   code=N/A        name=no-code-a
  id=15   code=pecst753   name=game-theory-and-mechanism-design
  id=21   code=N/A        name=no-code-b
exit=0
```

Flags the pair, ignores the unique code, ignores both `N/A` files, emits all five subjects, exits 0.

## Why the real data has this

`PECST753` is printed twice in **KTU's own 2024 CSE syllabus document**, once for Fuzzy Systems and once for Game Theory and Mechanism Design. Not every clash is a transcription error, so this warns rather than blames.